### PR TITLE
feat: Support Angular propDecorators inputs and outputs

### DIFF
--- a/lib/common/reflect.ts
+++ b/lib/common/reflect.ts
@@ -27,7 +27,7 @@ function getPropDecorators(directive: any, type: 'Input' | 'Output') {
     (decorators[propName] as any[])
       .filter((decorator: any) => decorator.type.prototype.ngMetadataName === type)
       .forEach((decorator: any) =>
-        fields.push(`${propName}:${decorator.args[0] || propName}`));
+        fields.push(`${propName}:${decorator.args && decorator.args[0] || propName}`));
   });
   return fields;
 }

--- a/lib/common/reflect.ts
+++ b/lib/common/reflect.ts
@@ -13,5 +13,21 @@ export function getInputsOutputs(directive: Type<Component | Directive>, type: '
   return Object.keys(propertyMetadata)
                .filter((meta) => propertyMetadata[meta].find((m: any) => m.ngMetadataName === type))
                .reduce(metaReducer(propertyMetadata), [])
+               .concat(getPropDecorators(directive, type))
                .concat(getInputsOutputs((directive as any).__proto__, type));
+}
+
+function getPropDecorators(directive: any, type: 'Input' | 'Output') {
+  const decorators = directive.propDecorators;
+  if (!decorators) {
+    return [];
+  }
+  const fields: any[] = [];
+  Object.keys(decorators).forEach((propName) => {
+    (decorators[propName] as any[])
+      .filter((decorator: any) => decorator.type.prototype.ngMetadataName === type)
+      .forEach((decorator: any) =>
+        fields.push(`${propName}:${decorator.args[0] || propName}`));
+  });
+  return fields;
 }

--- a/lib/mock-directive/mock-directive.spec.ts
+++ b/lib/mock-directive/mock-directive.spec.ts
@@ -1,6 +1,6 @@
 import { Component, Directive, EventEmitter, Input, Output } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { FormControlDirective } from '@angular/forms';
+import { FormControl, FormControlDirective } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { MockDirective } from './mock-directive';
 
@@ -19,10 +19,12 @@ export class ExampleDirective {
   template: `
     <div [exampleDirective]="'bye'" [bah]="'hi'" #f="foo" (someOutput)="emitted = $event"></div>
     <div exampleDirective></div>
+    <input [formControl]="fooControl"/>
   `
 })
 export class ExampleComponentContainer {
   emitted = false;
+  foo = new FormControl('');
 } // tslint:disable-line:max-classes-per-file
 
 describe('MockDirective', () => {
@@ -32,6 +34,7 @@ describe('MockDirective', () => {
     TestBed.configureTestingModule({
       declarations: [
         ExampleComponentContainer,
+        MockDirective(FormControlDirective),
         MockDirective(ExampleDirective)
       ]
     })
@@ -73,8 +76,7 @@ describe('MockDirective', () => {
     // I found that FormControlDirective is one of those weird directives.
     // Since I don't know how they did it, I don't know how to test it except to write this
     // Test around a known-odd directive.
-    expect(() => {
-      MockDirective(FormControlDirective);
-    }).not.toThrow();
+    const debugElement = fixture.debugElement.query(By.directive(MockDirective(ExampleDirective)));
+    expect(debugElement).not.toBeNull();
   });
 });


### PR DESCRIPTION
There is yet *another* way to add inputs on an Angular directive. I found that `FormConrolDirective` used a `propDecorators` object. Looking at the [source](https://github.com/angular/angular/blob/master/packages/forms/src/directives/reactive_directives/form_control_directive.ts#L144), I don't see anything special about what they are doing but for whatever reason, the inputs/outputs show up under the `<DirectiveClass>.propDecorators` object.

~~TODO: Should probably consider automatically hooking up output emitters on directives like it's done with components. If people are using `@angular/forms` junk, they'll likely run into it for things like `(ngOnChange)`.~~