### PR TITLE
Update mock component allowing the use of simulated reactive forms events 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 dist
 .DS_Store
 .git
+.idea

--- a/lib/mock-component/mock-component.spec.ts
+++ b/lib/mock-component/mock-component.spec.ts
@@ -21,7 +21,6 @@ import { SimpleComponent } from './test-components/simple-component.component';
       <custom-form-control [formControl]="formControl"></custom-form-control>
       <empty-component id="ng-content-component">doh</empty-component>
       <empty-component id="ngmodel-component" [(ngModel)]="someOutputHasEmitted"></empty-component>
-      <
   `
 })
 export class ExampleComponentContainer {
@@ -38,20 +37,19 @@ describe('MockComponent', () => {
       declarations: [
         ExampleComponentContainer,
         MockComponents(EmptyComponent,
-          SimpleComponent,
-          CustomFormControlComponent,
-        ),
+                       SimpleComponent,
+                       CustomFormControlComponent),
       ],
       imports: [
         FormsModule,
         ReactiveFormsModule
       ]
     })
-      .compileComponents()
-      .then(() => {
-        fixture = TestBed.createComponent(ExampleComponentContainer);
-        component = fixture.componentInstance;
-      });
+    .compileComponents()
+    .then(() => {
+      fixture = TestBed.createComponent(ExampleComponentContainer);
+      component = fixture.componentInstance;
+    });
   }));
 
   it('should have use the original component\'s selector', () => {

--- a/lib/mock-component/mock-component.ts
+++ b/lib/mock-component/mock-component.ts
@@ -39,8 +39,9 @@ export function MockComponent<TComponent>(component: Type<TComponent>): Type<TCo
     }
 
     /* tslint:disable:no-empty variable-name */
-    __simulateChange = (rating: number) => {};
+    __simulateChange = (param: any) => {};
     __simulateTouch = () => {};
+    /* tslint:enable:no-empty variable-name */
 
     registerOnChange = (fn: (value: any) => void) => {
       this.__simulateChange = fn;
@@ -49,8 +50,10 @@ export function MockComponent<TComponent>(component: Type<TComponent>): Type<TCo
     registerOnTouched(fn: () => void): void {
       this.__simulateTouch = fn;
     }
+
+    /* tslint:disable:no-empty */
     writeValue = (value: any) => {};
-    /* tslint:enable:no-empty variable-name */
+    /* tslint:enable:no-empty */
   }
 
   /* tslint:disable:no-angle-bracket-type-assertion */

--- a/lib/mock-component/mock-component.ts
+++ b/lib/mock-component/mock-component.ts
@@ -38,11 +38,19 @@ export function MockComponent<TComponent>(component: Type<TComponent>): Type<TCo
       });
     }
 
-    /* tslint:disable:no-empty */
-    registerOnChange = (fn: (value: any) => void) => {};
-    registerOnTouched = (fn: (value: any) => void) => {};
+    /* tslint:disable:no-empty variable-name */
+    __simulateChange = (rating: number) => {};
+    __simulateTouch = () => {};
+
+    registerOnChange = (fn: (value: any) => void) => {
+      this.__simulateChange = fn;
+    }
+
+    registerOnTouched(fn: () => void): void {
+      this.__simulateTouch = fn;
+    }
     writeValue = (value: any) => {};
-    /* tslint:enable:no-empty */
+    /* tslint:enable:no-empty variable-name */
   }
 
   /* tslint:disable:no-angle-bracket-type-assertion */

--- a/lib/mock-component/test-components/custom-form-control.component.ts
+++ b/lib/mock-component/test-components/custom-form-control.component.ts
@@ -1,0 +1,92 @@
+// sample control value accessor copied from
+// https://alligator.io/angular/custom-form-control/
+
+import { Component, forwardRef, HostBinding, Input } from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+
+const STARS = 5;
+const OPACITY = 0.25;
+
+@Component({
+  providers: [
+    {
+      multi: true,
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => CustomFormControlComponent),
+    }
+  ],
+  selector: 'custom-form-control',
+  styles: [`
+      span {
+          display: inline-block;
+          width: 25px;
+          line-height: 25px;
+          text-align: center;
+          cursor: pointer;
+      }
+  `],
+  template: `
+      <span
+              *ngFor="let starred of stars; let i = index"
+              (click)="onTouched(); rate(i + (starred ? (value > i + 1 ? 1 : 0) : 1))">
+      <ng-container *ngIf="starred; else noStar">⭐</ng-container>
+      <ng-template #noStar>·</ng-template>
+    </span>
+  `,
+})
+export class CustomFormControlComponent implements ControlValueAccessor {
+
+  @Input() disabled = false;
+  stars: boolean[] = Array(STARS).fill(false);
+
+  // Allow the input to be disabled, and when it is make it somewhat transparent.
+  @HostBinding('style.opacity')
+  get opacity() {
+    return this.disabled ? OPACITY : 1;
+  }
+
+  /* tslint:disable:no-empty */
+  // Function to call when the rating changes.
+  onChange = (rating: number) => {};
+
+  // Function to call when the input is touched (when a star is clicked).
+  // @ts-ignore
+  onTouched = () => {};
+  /* tslint:enable:no-empty */
+
+  get value(): number {
+    return this.stars.reduce((total, starred) =>
+      total + (starred ? 1 : 0),
+      0);
+  }
+
+  rate(rating: number) {
+    if (!this.disabled) {
+      this.writeValue(rating);
+    }
+  }
+
+  // Allows Angular to register a function to call when the model (rating) changes.
+  // Save the function as a property to call later here.
+  registerOnChange(fn: (rating: number) => void): void {
+    this.onChange = fn;
+  }
+
+  // Allows Angular to register a function to call when the input has been touched.
+  // Save the function as a property to call later here.
+  registerOnTouched(fn: () => void): void {
+    this.onTouched = fn;
+  }
+
+  // Allows Angular to disable the input.
+  setDisabledState(isDisabled: boolean): void {
+    this.disabled = isDisabled;
+  }
+
+  // Allows Angular to update the model (rating).
+  // Update the model and changes needed for the view here.
+  writeValue(rating: number): void {
+    this.stars = this.stars.map((_, i) => rating > i);
+    this.onChange(this.value);
+  }
+}

--- a/lib/mock-component/test-components/custom-form-control.component.ts
+++ b/lib/mock-component/test-components/custom-form-control.component.ts
@@ -1,11 +1,5 @@
-// sample control value accessor copied from
-// https://alligator.io/angular/custom-form-control/
-
-import { Component, forwardRef, HostBinding, Input } from '@angular/core';
+import { Component, forwardRef, Input } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-
-const STARS = 5;
-const OPACITY = 0.25;
 
 @Component({
   providers: [
@@ -16,77 +10,34 @@ const OPACITY = 0.25;
     }
   ],
   selector: 'custom-form-control',
-  styles: [`
-      span {
-          display: inline-block;
-          width: 25px;
-          line-height: 25px;
-          text-align: center;
-          cursor: pointer;
-      }
-  `],
   template: `
-      <span
-              *ngFor="let starred of stars; let i = index"
-              (click)="onTouched(); rate(i + (starred ? (value > i + 1 ? 1 : 0) : 1))">
-      <ng-container *ngIf="starred; else noStar">⭐</ng-container>
-      <ng-template #noStar>·</ng-template>
-    </span>
+      <span>{{value}}</span>
+      <button (click)="this.onChange('changed')">Change value</button>
   `,
 })
 export class CustomFormControlComponent implements ControlValueAccessor {
 
   @Input() disabled = false;
-  stars: boolean[] = Array(STARS).fill(false);
-
-  // Allow the input to be disabled, and when it is make it somewhat transparent.
-  @HostBinding('style.opacity')
-  get opacity() {
-    return this.disabled ? OPACITY : 1;
-  }
+  public value = '';
 
   /* tslint:disable:no-empty */
-  // Function to call when the rating changes.
-  onChange = (rating: number) => {};
-
-  // Function to call when the input is touched (when a star is clicked).
-  // @ts-ignore
+  onChange = (value: string) => {};
   onTouched = () => {};
   /* tslint:enable:no-empty */
 
-  get value(): number {
-    return this.stars.reduce((total, starred) =>
-      total + (starred ? 1 : 0),
-      0);
-  }
-
-  rate(rating: number) {
-    if (!this.disabled) {
-      this.writeValue(rating);
-    }
-  }
-
-  // Allows Angular to register a function to call when the model (rating) changes.
-  // Save the function as a property to call later here.
-  registerOnChange(fn: (rating: number) => void): void {
+  registerOnChange(fn: (rating: string) => void): void {
     this.onChange = fn;
   }
 
-  // Allows Angular to register a function to call when the input has been touched.
-  // Save the function as a property to call later here.
   registerOnTouched(fn: () => void): void {
     this.onTouched = fn;
   }
 
-  // Allows Angular to disable the input.
   setDisabledState(isDisabled: boolean): void {
     this.disabled = isDisabled;
   }
 
-  // Allows Angular to update the model (rating).
-  // Update the model and changes needed for the view here.
-  writeValue(rating: number): void {
-    this.stars = this.stars.map((_, i) => rating > i);
-    this.onChange(this.value);
+  writeValue(value: string): void {
+    this.value = value;
   }
 }


### PR DESCRIPTION
Allow mock component to support reactive form component: ControlValueAccessor events. 

Two methods added
__simulateTouch - lets you simulate the touch event on that reactive form component being called.
__simulateChange - lets you simulate the value change event on the reactive form component being called.