### PR TITLE
Support Angular component query decorators

### DIFF
--- a/lib/mock-component/mock-component.spec.ts
+++ b/lib/mock-component/mock-component.spec.ts
@@ -1,8 +1,9 @@
-import { Component } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { MockComponent, MockComponents, MockedComponent } from './mock-component';
+import { ChildComponent } from './test-components/child-component.component';
 import { CustomFormControlComponent } from './test-components/custom-form-control.component';
 import { EmptyComponent } from './test-components/empty-component.component';
 import { SimpleComponent } from './test-components/simple-component.component';
@@ -21,11 +22,17 @@ import { SimpleComponent } from './test-components/simple-component.component';
     <custom-form-control [formControl]="formControl"></custom-form-control>
     <empty-component id="ng-content-component">doh</empty-component>
     <empty-component id="ngmodel-component" [(ngModel)]="someOutputHasEmitted"></empty-component>
+    <child-component></child-component>
   `
 })
 export class ExampleComponentContainer {
+  @ViewChild(ChildComponent) childComponent: ChildComponent;
   emitted: string;
   formControl = new FormControl('');
+
+  performActionOnChild(s: string): void {
+    this.childComponent.performAction(s);
+  }
 }
 
 describe('MockComponent', () => {
@@ -38,6 +45,7 @@ describe('MockComponent', () => {
         ExampleComponentContainer,
         MockComponents(EmptyComponent,
                        SimpleComponent,
+                       ChildComponent,
                        CustomFormControlComponent),
       ],
       imports: [
@@ -121,6 +129,17 @@ describe('MockComponent', () => {
     expect(MockComponent(EmptyComponent)).toBe(MockComponent(EmptyComponent));
     expect(MockComponent(SimpleComponent)).toBe(MockComponent(SimpleComponent));
     expect(MockComponent(EmptyComponent)).not.toBe(MockComponent(SimpleComponent));
+  });
+
+  it('should set ViewChild components correctly', () => {
+    fixture.detectChanges();
+    expect(component.childComponent).toBeTruthy();
+  });
+
+  it('should allow spying of viewchild component methods', () => {
+    const spy = spyOn(component.childComponent, 'performAction');
+    component.performActionOnChild('test');
+    expect(spy).toHaveBeenCalledWith('test');
   });
 
   describe('ReactiveForms - ControlValueAccessor', () => {

--- a/lib/mock-component/mock-component.ts
+++ b/lib/mock-component/mock-component.ts
@@ -2,6 +2,7 @@ import { Component, EventEmitter, forwardRef, Type } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { MockOf } from '../common';
 import { directiveResolver } from '../common/reflect';
+import { MockedComponent } from './mock-component';
 
 const cache = new Map<Type<Component>, Type<Component>>();
 
@@ -30,6 +31,10 @@ export function MockComponent<TComponent>(component: Type<TComponent>): Type<TCo
       multi: true,
       provide: NG_VALUE_ACCESSOR,
       useExisting: forwardRef(() => ComponentMock)
+    },
+    {
+      provide: component,
+      useExisting: forwardRef(() => ComponentMock)
     }],
     selector,
     template: '<ng-content></ng-content>'
@@ -38,6 +43,12 @@ export function MockComponent<TComponent>(component: Type<TComponent>): Type<TCo
   @MockOf(component)
   class ComponentMock implements ControlValueAccessor {
     constructor() {
+      Object.keys(component.prototype).forEach((method) => {
+        if (!(this as any)[method]) {
+          (this as any)[method] = () => {};
+        }
+      });
+
       (options.outputs || []).forEach((output) => {
         (this as any)[output.split(':')[0]] = new EventEmitter<any>();
       });

--- a/lib/mock-component/test-components/child-component.component.ts
+++ b/lib/mock-component/test-components/child-component.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'child-component',
+  template: 'some template'
+})
+export class ChildComponent {
+  performAction(s: string) {
+    return this;
+  }
+}


### PR DESCRIPTION
Added the ability to use ViewChild/ViewChildren etc with MockComponent. Also ensured that methods of the component are defined in the mock component, to allow spying. Created ChildComponent to test this functionality.