### PR TITLE
Removing a maximum angular version as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
   },
   "homepage": "https://github.com/ike18t/ng-mocks#readme",
   "peerDependencies": {
-    "@angular/compiler": ">=5.x <=6.x",
-    "@angular/core": ">=5.x <=6.x",
-    "@angular/forms": ">=5.x <=6.x"
+    "@angular/compiler": ">=5.x",
+    "@angular/core": ">=5.x",
+    "@angular/forms": ">=5.x"
   },
   "devDependencies": {
     "@angular/common": "6.x",


### PR DESCRIPTION
Given the high cadence and low impact of major version bumps in Angular it's unnecessary to specify (and continually increment) a maximum version of Angular as a peer dependency