### PR TITLE
Support of latest ngTemplateOutlet API + proper injection of CommonModule to mocked modules

### DIFF
--- a/lib/mock-component/mock-component.spec.ts
+++ b/lib/mock-component/mock-component.spec.ts
@@ -190,6 +190,10 @@ describe('MockComponent', () => {
       const block2 = templateOutlet.query(By.css('[data-key="block2"]'));
       expect(block2).toBeTruthy();
       expect(block2.nativeElement.innerText.trim()).toEqual('block 2 body');
+
+      // looking for 3rd templateRef. It shouldn't be present because wasn't passed.
+      const block3 = templateOutlet.query(By.css('[data-key="block3"]'));
+      expect(block3).toBeFalsy();
     });
   });
 });

--- a/lib/mock-component/mock-component.spec.ts
+++ b/lib/mock-component/mock-component.spec.ts
@@ -191,9 +191,10 @@ describe('MockComponent', () => {
       expect(block2).toBeTruthy();
       expect(block2.nativeElement.innerText.trim()).toEqual('block 2 body');
 
-      // looking for 3rd templateRef. It shouldn't be present because wasn't passed.
+      // looking for 3rd templateRef.
       const block3 = templateOutlet.query(By.css('[data-key="block3"]'));
-      expect(block3).toBeFalsy();
+      expect(block3).toBeTruthy();
+      expect(block3.nativeElement.innerText.trim()).toEqual('');
     });
   });
 });

--- a/lib/mock-component/mock-component.ts
+++ b/lib/mock-component/mock-component.ts
@@ -34,8 +34,8 @@ export function MockComponent<TComponent>(component: Type<TComponent>): Type<TCo
         if (typeof query.selector !== 'string') {
           return ''; // in case of mocked component, Type based selector doesn't work properly anyway.
         }
-        return `<div *ngIf="${key}" data-key="${query.selector}">
-          <template [ngTemplateOutlet]="${key}"></template>
+        return `<div data-key="${query.selector}">
+          <ng-container *ngTemplateOutlet="${key}"></ng-container>
         </div>`;
       }).join('');
   }

--- a/lib/mock-component/mock-component.ts
+++ b/lib/mock-component/mock-component.ts
@@ -34,7 +34,9 @@ export function MockComponent<TComponent>(component: Type<TComponent>): Type<TCo
         if (typeof query.selector !== 'string') {
           return ''; // in case of mocked component, Type based selector doesn't work properly anyway.
         }
-        return `<div data-key="${query.selector}"><template [ngTemplateOutlet]="${key}"></template></div>`;
+        return `<div *ngIf="${key}" data-key="${query.selector}">
+          <template [ngTemplateOutlet]="${key}"></template>
+        </div>`;
       }).join('');
   }
 

--- a/lib/mock-module/mock-module.ts
+++ b/lib/mock-module/mock-module.ts
@@ -14,6 +14,15 @@ const mockProvider = (provider: any) => ({
   provide: provider, useValue: {}
 });
 
+const flatten = <T>(values: T | T[], result: T[] = []): T[] => {
+    if (Array.isArray(values)) {
+        values.forEach((value: T | T[]) => flatten(value, result));
+    } else {
+        result.push(values);
+    }
+    return result;
+};
+
 export function MockModule(module: Type<NgModule>): Type<NgModule> {
   return NgModule(MockIt(module))(class MockedModule {});
 }
@@ -30,11 +39,10 @@ function MockIt(module: Type<NgModule>): IModuleOptions {
                                          providers: [] };
   const { declarations = [], imports = [], providers = [] } = ngModuleResolver.resolve(module);
 
-  mockedModule.exports = mockedModule.declarations = [...declarations.map(MockDeclaration)];
-  mockedModule.providers = providers.map(mockProvider);
-  mockedModule.imports = [];
+  mockedModule.exports = mockedModule.declarations = flatten(declarations).map(MockDeclaration);
+  mockedModule.providers = flatten(providers).map(mockProvider);
 
-  imports.forEach((imPort: Type<NgModule>) => {
+  flatten(imports).forEach((imPort: Type<NgModule>) => {
     const result = MockIt(imPort);
     if ((result as any) === imPort) {
       mockedModule.imports.push(imPort);

--- a/lib/mock-module/mock-module.ts
+++ b/lib/mock-module/mock-module.ts
@@ -6,6 +6,7 @@ import { MockDeclaration } from '../mock-declaration';
 interface IModuleOptions {
   declarations: Array<Type<any>>;
   exports: Array<Type<any>>;
+  imports: Array<Type<any>>;
   providers: Array<{ provide: any; useValue: {} }>;
 }
 
@@ -25,17 +26,23 @@ function MockIt(module: Type<NgModule>): IModuleOptions {
   }
   const mockedModule: IModuleOptions = { declarations: [],
                                          exports: [],
+                                         imports: [],
                                          providers: [] };
   const { declarations = [], imports = [], providers = [] } = ngModuleResolver.resolve(module);
 
   mockedModule.exports = mockedModule.declarations = [...declarations.map(MockDeclaration)];
   mockedModule.providers = providers.map(mockProvider);
+  mockedModule.imports = [];
 
   imports.forEach((imPort: Type<NgModule>) => {
     const result = MockIt(imPort);
-    mockedModule.declarations.push(...result.declarations);
-    mockedModule.providers.push(...result.providers);
-    mockedModule.exports.push(...result.declarations);
+    if ((result as any) === imPort) {
+      mockedModule.imports.push(imPort);
+    } else {
+      mockedModule.declarations.push(...result.declarations);
+      mockedModule.providers.push(...result.providers);
+      mockedModule.exports.push(...result.declarations);
+    }
   });
 
   return mockedModule;


### PR DESCRIPTION
Found interesting case: with nested components undefined blocks could cause "Can't bind to 'ngTemplateOutlet' since it isn't a known property of 'template'" error - and the problem was cased due to CommonModule wasn't injected properly to mocked module.