### PR TITLE
Support mock of ModuleWithProviders

### DIFF
--- a/lib/mock-module/mock-module.spec.ts
+++ b/lib/mock-module/mock-module.spec.ts
@@ -3,7 +3,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { MockComponent } from '../mock-component';
 import { MockModule } from './mock-module';
-import { ExampleComponent, ParentModule } from './test-fixtures';
+import { ExampleComponent, ModuleWithProvidersModule, ParentModule } from './test-fixtures';
 
 @Component({
   selector: 'component-subject',
@@ -26,7 +26,8 @@ describe('MockModule', () => {
         ComponentSubject
       ],
       imports: [
-        MockModule(ParentModule)
+        MockModule(ParentModule),
+        MockModule(ModuleWithProvidersModule),
       ],
     })
     .compileComponents()

--- a/lib/mock-module/test-fixtures.ts
+++ b/lib/mock-module/test-fixtures.ts
@@ -1,7 +1,7 @@
 /* tslint:disable:max-classes-per-file */
 
 import { CommonModule } from '@angular/common';
-import { Component, Directive, Injectable, NgModule, Pipe, PipeTransform } from '@angular/core';
+import { Component, Directive, Injectable, ModuleWithProviders, NgModule, Pipe, PipeTransform } from '@angular/core';
 
 @Directive({selector: '[example-directive]'})
 export class ExampleDirective {}
@@ -40,3 +40,40 @@ export class ChildModule {}
   imports: [ ChildModule ],
 })
 export class ParentModule {}
+
+/* Assets for ModuleWithProviders BEGIN */
+
+// Simple module, one of components requires some special provider.
+@NgModule({
+  imports: [
+    CommonModule,
+  ],
+})
+class RealModuleWithProvidersModule {}
+
+// Factory to setup module with provider.
+/* tslint:disable:no-unnecessary-class */
+class ModuleProvider {
+  static withFlag(flag: boolean): ModuleWithProviders {
+    return {
+      ngModule: RealModuleWithProvidersModule,
+      providers: [
+        {
+          provide: 'MODULE_FLAG',
+          useValue: flag,
+        },
+      ],
+    };
+  }
+}
+/* tslint:enable:no-unnecessary-class */
+
+// Encapsulating module with provider in some random module.
+@NgModule({
+  imports: [
+    ModuleProvider.withFlag(false),
+  ],
+})
+export class ModuleWithProvidersModule {}
+
+/* Assets for ModuleWithProviders END */


### PR DESCRIPTION
There’re some NgModules with providers like
 * `RouterModule.forRoot`
 * `RouterModule.forChild`
 * `TinymceModule.withConfig`

They return `ModuleWithProviders` instead of `NgModule` and it requires special handling.