### PR TITLE
Ionic support

### DIFF
--- a/lib/mock-component/mock-component.ts
+++ b/lib/mock-component/mock-component.ts
@@ -1,3 +1,4 @@
+import { core } from '@angular/compiler';
 import {
   ChangeDetectorRef,
   Component,
@@ -7,7 +8,7 @@ import {
   TemplateRef,
   Type,
   ViewChild,
-  ViewContainerRef
+  ViewContainerRef,
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
@@ -28,16 +29,16 @@ export type MockedComponent<T> = T & {
 };
 
 export function MockComponents(...components: Array<Type<any>>): Array<Type<any>> {
-  return components.map(MockComponent);
+  return components.map((component) => MockComponent(component, undefined));
 }
 
-export function MockComponent<TComponent>(component: Type<TComponent>): Type<TComponent> {
+export function MockComponent<TComponent>(component: Type<TComponent>, metaData?: core.Directive): Type<TComponent> {
   const cacheHit = cache.get(component);
   if (cacheHit) {
     return cacheHit as Type<TComponent>;
   }
 
-  const { exportAs, inputs, outputs, queries, selector } = directiveResolver.resolve(component);
+  const { exportAs, inputs, outputs, queries, selector } = metaData || directiveResolver.resolve(component);
 
   let template = `<ng-content></ng-content>`;
   const viewChildRefs = new Map<string, string>();


### PR DESCRIPTION
Added the capability for providing your own, custom decorator meta-data (useful when wanting to mock Components from ionicframework).

Since ionic framework (https://ionicframework.com/) is build using web components (using stencil.js: https://stenciljs.com/), ng-mocks can't seem to derive the decorator meta-data (since there isn't any) - this allows the user of ng-mocks to manually provide it:

**Usage:**
Add ionic framework to an existing / new Angular application:
```ng add @ionic/angular```

_`app.component.html`-file:_
```html
<ion-button (ionFocus)="focus()">Test</ion-button>
```
_`app.component.ts`-file:_
```typescript
import { Component } from '@angular/core';

@Component({
  selector: 'app-root',
  templateUrl: './app.component.html',
  styleUrls: ['./app.component.scss']
})
export class AppComponent {
  focus() {
    console.log('Button got focused');
  }
}
```

_`app.component.spec.ts`-file:_
```typescript
import { async, ComponentFixture, TestBed } from '@angular/core/testing';
import { AppComponent } from './app.component';
import { MockComponent } from 'ng-mocks';
import { IonButton } from '@ionic/angular';
import { By } from '@angular/platform-browser';

describe('AppComponent', () => {
  let fixture: ComponentFixture<AppComponent>;
  let component: AppComponent;

  let button: IonButton;

  beforeEach(async(() => {
    TestBed.configureTestingModule({
      declarations: [
        AppComponent,
        MockComponent(IonButton, {
          selector: 'ion-button',
          outputs: ['ionFocus'],
        }),
      ],
    }).compileComponents();

    fixture = TestBed.createComponent(AppComponent);
    component = fixture.debugElement.componentInstance as AppComponent;

    button = fixture.debugElement
      .query(By.css('ion-button'))
      .componentInstance as IonButton;
  }));

  it('test focus-binding', () => {
    spyOn(component, 'focus');
    button.ionFocus.emit();
    expect(component.focus).toHaveBeenCalled();
  });
});

```
