### PR TITLE
Export both MockPipe and MockPipes

### DIFF
--- a/lib/mock-pipe/index.ts
+++ b/lib/mock-pipe/index.ts
@@ -1,1 +1,1 @@
-export { MockPipe } from './mock-pipe';
+export * from './mock-pipe';


### PR DESCRIPTION
Hi,

I would like to have ability to import MockPipes directly from ng-mocks, without using full path.