### PR TITLE
fix: es2015 class declaration method mocking

### DIFF
--- a/lib/mock-component/mock-component.ts
+++ b/lib/mock-component/mock-component.ts
@@ -93,7 +93,7 @@ export function MockComponent<TComponent>(component: Type<TComponent>, metaData?
   @MockOf(component)
   class ComponentMock implements ControlValueAccessor {
     constructor(changeDetector: ChangeDetectorRef) {
-      Object.keys(component.prototype).forEach((method) => {
+      Object.getOwnPropertyNames(component.prototype).forEach((method) => {
         if (!(this as any)[method]) {
           (this as any)[method] = () => {};
         }

--- a/lib/mock-directive/mock-directive.ts
+++ b/lib/mock-directive/mock-directive.ts
@@ -70,7 +70,7 @@ export function MockDirective<TDirective>(directive: Type<TDirective>): Type<Moc
       (this as any).__viewContainer = viewContainer;
       (this as any).__isStructural = template && viewContainer;
 
-      Object.keys(directive.prototype).forEach((method) => {
+      Object.getOwnPropertyNames(directive.prototype).forEach((method) => {
         if (!(this as any)[method]) {
           (this as any)[method] = () => {};
         }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es2016", "dom"],
     "module": "commonjs",
-    "target": "es5",
+    "target": "es2015",
     "noImplicitAny": true,
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
Angular 8 switches TS target to `es2015` and primary bundle contains ES6 class declaration and because of that method mocking in `MockDirective` and `MockComponent` no longer works.

The problem is that native JS class methods are not enumerable and thus `Object.keys` cannot be used. `Object.getOwnPropertyNames` should be used instead to enumerate non enumerable properties.

PR contains changes needed to make mocking work in es2015 environment and are backwards compatible.