### PR TITLE
added MockService helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,70 @@ returns first found attribute or structural directive which belongs to current e
 `MockHelper.findDirectives(fixture.debugElement, Directive)`
 returns all found attribute or structural directives which belong to current element and all its child.
 
+## MockService
+
+* extends the original service with optional passing of it's dependencies
+* assumes that you will use `spyOn(..)` for stubbing real methods
+
+### Usage Example
+```typescript
+@Injectable()
+export class NumbersService {
+  constructor(private httpClient: HttpClient) {}
+
+  getNumbers() {
+    return this.httpClient.get<number[]>('/numbers');
+  }
+}
+
+describe('NumbersService', () => {
+  let service: NumberService;
+  let http: HttpClient;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        NumbersService,
+        MockService(HttpClient),
+      ]
+    });
+
+    service = TestBed.get(NumbersService);
+    http = TestBed.get(HttpClient)
+  });
+
+  describe('getNumbers', () => {
+    it('should fetch numbers', () => {
+      spyOn(http, 'get').and.returnValue(of([1]));
+   
+      service.getNumbers().subscribe((result) => {
+        expect(result).toEqual([1]);
+      });
+    });   
+  });
+});
+````
+
+## MockedServiceInstance
+
+* useful for getting mocked service instance
+
+### Usage Example
+```typescript
+describe('NumbersService', () => {
+  let service: NumberService;
+  let http: HttpClient;
+
+  beforeEach(() => {
+    http = MockedServiceInstance(HttpClient);
+    service = new NumberService(http);  
+  });
+
+  // ...
+
+});
+````
+
 ## Other examples of tests
 More detailed examples can be found in
 [e2e](https://github.com/ike18t/ng-mocks/tree/master/e2e)

--- a/lib/mock-service/mock-service.spec.ts
+++ b/lib/mock-service/mock-service.spec.ts
@@ -1,0 +1,49 @@
+import { HttpClient } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { MockedServiceInstance, MockService } from './mock-service';
+import { NumbersService } from './test-services/numbers.service';
+import { StringsService } from './test-services/strings.service';
+
+describe('MockService', () => {
+  describe('when service does not require deps in constructor', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          MockService(NumbersService),
+        ]
+      });
+    });
+
+    it('should allow to mock service', () => {
+      const service: NumbersService = TestBed.get(NumbersService);
+      spyOn(service, 'getNumbers').and.returnValue(of([1]));
+
+      service.getNumbers().subscribe((result) => {
+        expect(result).toEqual([1]);
+      });
+    });
+  });
+
+  describe('when service requires deps in constructor', () => {
+    beforeEach(() => {
+      const http = MockedServiceInstance(HttpClient);
+      spyOn(http, 'get').and.returnValue(of(['other']));
+
+      TestBed.configureTestingModule({
+        providers: [
+          MockService(StringsService, [http]),
+        ]
+      });
+    });
+
+    it('should allow to mock service', () => {
+      const service: StringsService = TestBed.get(StringsService);
+      spyOn(service, 'getStrings').and.returnValue(of(['test']));
+
+      service.getStrings().subscribe((result) => {
+        expect(result).toEqual(['test']);
+      });
+    });
+  });
+});

--- a/lib/mock-service/mock-service.ts
+++ b/lib/mock-service/mock-service.ts
@@ -1,0 +1,31 @@
+import { Injectable, Type, ValueProvider } from '@angular/core';
+import { MockOf } from '../common';
+
+function getErrorMessage(className: string): string {
+  return `
+    Failed to mock ${className}.
+    Perhaps it requires injected dependencies in the constructor.
+    Try providing them in MockService(YourService, [deps])`;
+}
+
+export function MockService<TService>(service: Type<TService>, deps: any[] = []): ValueProvider {
+  return {provide: service, useValue: MockedServiceInstance<TService>(service, deps)};
+}
+
+export function MockedServiceInstance<TService = any>(service: Type<TService>, deps: any[] = []): TService {
+  @MockOf(service)
+  class ServiceMock extends (service as any) {
+    constructor() {
+      try {
+        super(...deps);
+      } catch ({name, stack, message}) {
+        message = `${getErrorMessage(service.name)}\n\n${message}}`;
+        throw  {name, message, stack};
+      }
+    }
+  }
+
+  // tslint:disable-next-line:no-angle-bracket-type-assertion
+  const mockedService = Injectable()(<any> ServiceMock as Type<TService>);
+  return new mockedService();
+}

--- a/lib/mock-service/test-services/numbers.service.ts
+++ b/lib/mock-service/test-services/numbers.service.ts
@@ -1,0 +1,15 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class NumbersService {
+  private readonly httpClient: HttpClient;
+
+  constructor(httpClient: HttpClient) {
+    this.httpClient = httpClient;
+  }
+
+  getNumbers() {
+    return this.httpClient.get<number[]>('/numbers');
+  }
+}

--- a/lib/mock-service/test-services/strings.service.ts
+++ b/lib/mock-service/test-services/strings.service.ts
@@ -1,0 +1,20 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+
+@Injectable()
+export class StringsService {
+  private readonly httpClient: HttpClient;
+  private readonly strings: BehaviorSubject<string[]> = new BehaviorSubject<string[]>([]);
+
+  constructor(httpClient: HttpClient) {
+    this.httpClient = httpClient;
+    this.httpClient.get<string[]>('/strings').subscribe((strings) => {
+      this.strings.next(strings);
+    });
+  }
+
+  getStrings(): Observable<string[]> {
+    return this.strings;
+  }
+}


### PR DESCRIPTION
Hi! Thanks for implementing such a helpful mocking tools! I used it on many projects.
The only one thing missing is ability to mock Angular services. I know there is ts-mockery package, but I thought about implementing `MockService` helper, that would be even easier for typical uses. With that solution the ng-mocks would be a complete solution :)

Consider such a component with injected dependency

```typescript
@Component({...})
class SomeComponent {
  constructor(private service: SomeService) {}

  ngOnInit() {
    this.service.getItems().subscribe(...)
  }
}
```

It could be tested with using `MockService(...)` helper

```typescript
beforeEach(() => {
  TestBed.configureTestingModule({
    declarations: [SomeComponent],
    providers: [MockService(ItemsService)]
  });
  
  const service = TestBed.get(ItemsService);
  spyOn(service, 'getItems').and.returnValue(of(['item 1', 'item 2']));

  fixture = TestBed.createComponent(SomeComponent);
  fixture.detectChanges();
})
```

Spying  `getItems` method in separate instruction gives more flexibility in case we would like testing the failing scenario, example:

```typescript
  spyOn(service, 'getItems').and.returnValue(throwError(new Error('failed to fetch items')));
```

What do you think about this :)?
Best wishes, Tomasz