### PR TITLE
feat: Mocking service

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,37 +1,25 @@
 #!/bin/bash
-echo "${0}:start"
+set -e
 
 child_pid=0
 parent_pid=$$
 
-trap catch_exits TERM KILL INT
-
-catch_exits() {
-    echo "${0}:stop '${child_pid}'"
-    kill ${child_pid} &
-    wait
-    echo "${0}:exit"
-    exit 1
-}
-
-set -e
-command=${@}
-
-for file in `ls -v /docker-entrypoint.d/*.sh`
-do
-    echo "${0}:entry '${file}'"
-    sh -c "${file}"
-    if [[ "${?}" != "0" ]]; then
-        exit 1;
-    fi
-done
-
 fork() {
-    echo "${0}:command '${command}'"
-    sh -c "${command}"
+    echo ${@} | xargs -t -I % sh -c "%"
 }
 
-fork &
+if [[ ! "${ENTRYPOINT_SKIP}" ]]; then
+for file in `ls -v /docker-entrypoint.d/*.sh`
+    do
+        fork ${file} &
+        child_pid=$!
+        wait ${child_pid}
+        if [[ "${?}" != "0" ]]; then
+            exit 1;
+        fi
+    done
+fi
+
+fork ${@} &
 child_pid=$!
-echo "${0}:child '${child_pid}'"
 wait ${child_pid}

--- a/index.ts
+++ b/index.ts
@@ -3,6 +3,7 @@ export * from './lib/mock-component';
 export * from './lib/mock-declaration';
 export * from './lib/mock-directive';
 export * from './lib/mock-helper';
-export * from './lib/mock-render';
 export * from './lib/mock-module';
 export * from './lib/mock-pipe';
+export * from './lib/mock-render';
+export * from './lib/mock-service';

--- a/lib/mock-module/mock-module.spec.ts
+++ b/lib/mock-module/mock-module.spec.ts
@@ -5,12 +5,10 @@ import { Component } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserModule, By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { MockComponent, MockModule, MockRender } from 'ng-mocks';
 
-import { MockComponent } from '../mock-component';
-
-import { MockModule } from './mock-module';
 import {
-  AppRoutingModule,
+  AppRoutingModule, CustomWithServiceComponent,
   ExampleComponent,
   ExampleConsumerComponent,
   LogicNestedModule,
@@ -18,7 +16,7 @@ import {
   ModuleWithProvidersModule,
   ParentModule,
   SameImports1Module,
-  SameImports2Module
+  SameImports2Module, WithServiceModule,
 } from './test-fixtures';
 
 @Component({
@@ -199,6 +197,24 @@ describe('Usage of cached nested module', () => {
 
   });
 
+});
+
+describe('WithServiceModule', () => {
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        CustomWithServiceComponent,
+      ],
+      imports: [
+        MockModule(WithServiceModule),
+      ],
+    });
+  }));
+
+  it('should not throw an error of service method', () => {
+    const fixture = MockRender('<custom-service></custom-service>');
+    expect(fixture).toBeDefined();
+  });
 });
 
 // TODO> Doesn't work because ParentModule doesn't export anything.

--- a/lib/mock-module/mock-module.ts
+++ b/lib/mock-module/mock-module.ts
@@ -1,9 +1,8 @@
 import { CommonModule } from '@angular/common';
 import { ModuleWithProviders, NgModule, Provider, Type } from '@angular/core';
+import { MockDeclaration, MockOf, MockService } from 'ng-mocks';
 
-import { MockOf } from '../common';
 import { jitReflector, ngModuleResolver } from '../common/reflect';
-import { MockDeclaration } from '../mock-declaration';
 
 const cache = new Map<Type<NgModule>, Type<NgModule>>();
 
@@ -44,20 +43,20 @@ const mockProvider = (provider: any): Provider | undefined => {
     typeof provide === 'object' && provide.ngMetadataName === 'InjectionToken'
     && neverMockProvidedToken.includes(provide.toString())
   ) {
-    return undefined;
+    return provider;
   }
 
   if (
     typeof provide === 'function'
     && neverMockProvidedFunction.includes(provide.name)
   ) {
-    return undefined;
+    return provider;
   }
 
   return {
     multi,
     provide,
-    useValue: {},
+    useValue: MockService(provide),
   };
 };
 

--- a/lib/mock-module/test-fixtures.ts
+++ b/lib/mock-module/test-fixtures.ts
@@ -136,4 +136,29 @@ class ModuleProvider {
 })
 export class ModuleWithProvidersModule {}
 
+// Checking services
+@Injectable()
+export class CustomService {
+  protected readonly value = 'dummy';
+
+  public getSomething(): string {
+    return this.value;
+  }
+}
+@Component({
+  selector: 'custom-service',
+  template: `same imports`
+})
+export class CustomWithServiceComponent {
+  public name: string;
+
+  constructor(service: CustomService) {
+    this.name = service.getSomething();
+  }
+}
+@NgModule({
+  providers: [CustomService],
+})
+export class WithServiceModule {}
+
 /* Assets for ModuleWithProviders END */

--- a/lib/mock-service/index.ts
+++ b/lib/mock-service/index.ts
@@ -1,0 +1,1 @@
+export * from './mock-service';

--- a/lib/mock-service/mock-service.spec.ts
+++ b/lib/mock-service/mock-service.spec.ts
@@ -1,0 +1,150 @@
+import { MockService } from 'ng-mocks';
+
+// tslint:disable:max-classes-per-file
+class DeepParentClass {
+  public deepParentMethodName = 'deepParentMethod';
+
+  public deepParentMethod() {
+    return this.deepParentMethodName;
+  }
+}
+
+class ParentClass extends DeepParentClass {
+  public overrideMeName = 'overrideMe';
+  public parentMethodName = 'parentMethod';
+
+  public overrideMe() {
+    return this.overrideMeName;
+  }
+
+  public parentMethod() {
+    return this.parentMethodName;
+  }
+}
+
+class ChildClass extends ParentClass {
+  public childMethodName = 'childMethod';
+  public overrideMeName = 'childOverrideMe';
+
+  public childMethod() {
+    return this.childMethodName;
+  }
+
+  public overrideMe() {
+    return this.overrideMeName;
+  }
+}
+
+// tslint:enable:max-classes-per-file
+
+describe('MockService', () => {
+  it('should convert boolean, number, string, null and undefined to undefined', () => {
+    expect(MockService(true)).toBeUndefined();
+    expect(MockService(false)).toBeUndefined();
+    expect(MockService(0)).toBeUndefined();
+    expect(MockService(1)).toBeUndefined();
+    expect(MockService(-1)).toBeUndefined();
+    expect(MockService(NaN)).toBeUndefined();
+    expect(MockService('')).toBeUndefined();
+    expect(MockService(null)).toBeUndefined(); // tslint:disable-line:no-null-keyword
+    expect(MockService(undefined)).toBeUndefined();
+  });
+
+  it('should convert an array of anything to an empty array', () => {
+    expect(MockService([1, 0, 1])).toEqual([]);
+    expect(MockService([new DeepParentClass()])).toEqual([]);
+  });
+
+  it('should convert functions to () => undefined', () => {
+    const mockedService = MockService(() => 0);
+    expect(mockedService).toEqual(jasmine.any(Function), 'mockedService');
+    expect(mockedService()).toBeUndefined();
+  });
+
+  it('should mock own methods of a class without a parent', () => {
+    const mockedService = MockService(DeepParentClass);
+
+    // all properties should be undefined, maybe defined as getters and setters.
+    expect(mockedService.deepParentMethodName).toBeUndefined('deepParentMethodName');
+
+    // all methods should be defined as functions which return undefined.
+    expect(mockedService.deepParentMethod).toEqual(jasmine.any(Function), 'deepParentMethod');
+    expect(mockedService.deepParentMethod()).toBeUndefined('deepParentMethod()');
+  });
+
+  it('should mock own and parent methods of a class', () => {
+    const mockedService = MockService(ChildClass);
+
+    // all properties should be undefined, maybe defined as getters and setters.
+    expect(mockedService.deepParentMethodName).toBeUndefined('deepParentMethodName');
+    expect(mockedService.parentMethodName).toBeUndefined('parentMethodName');
+    expect(mockedService.overrideMeName).toBeUndefined('overrideMeName');
+    expect(mockedService.childMethodName).toBeUndefined('childMethodName');
+
+    // all methods should be defined as functions which return undefined.
+    expect(mockedService.deepParentMethod).toEqual(jasmine.any(Function), 'deepParentMethod');
+    expect(mockedService.deepParentMethod()).toBeUndefined('deepParentMethod()');
+    expect(mockedService.parentMethod).toEqual(jasmine.any(Function), 'parentMethod');
+    expect(mockedService.parentMethod()).toBeUndefined('parentMethod()');
+    expect(mockedService.overrideMe).toEqual(jasmine.any(Function), 'overrideMe');
+    expect(mockedService.overrideMe()).toBeUndefined('overrideMe()');
+    expect(mockedService.childMethod).toEqual(jasmine.any(Function), 'childMethod');
+    expect(mockedService.childMethod()).toBeUndefined('childMethod()');
+  });
+
+  it('should mock an instance of a class as an object', () => {
+    const mockedService = MockService(new ChildClass());
+
+    // all properties should be undefined, maybe defined as getters and setters.
+    expect(mockedService.deepParentMethodName).toBeUndefined('deepParentMethodName');
+    expect(mockedService.parentMethodName).toBeUndefined('parentMethodName');
+    expect(mockedService.overrideMeName).toBeUndefined('overrideMeName');
+    expect(mockedService.childMethodName).toBeUndefined('childMethodName');
+
+    // all methods should be defined as functions which return undefined.
+    expect(mockedService.deepParentMethod).toEqual(jasmine.any(Function), 'deepParentMethod');
+    expect(mockedService.deepParentMethod()).toBeUndefined('deepParentMethod()');
+    expect(mockedService.parentMethod).toEqual(jasmine.any(Function), 'parentMethod');
+    expect(mockedService.parentMethod()).toBeUndefined('parentMethod()');
+    expect(mockedService.overrideMe).toEqual(jasmine.any(Function), 'overrideMe');
+    expect(mockedService.overrideMe()).toBeUndefined('overrideMe()');
+    expect(mockedService.childMethod).toEqual(jasmine.any(Function), 'childMethod');
+    expect(mockedService.childMethod()).toBeUndefined('childMethod()');
+  });
+
+  it('should mock own and nested properties of an object', () => {
+    const mockedService = MockService({
+      booleanFalse: false,
+      booleanTrue: true,
+      child1: {
+        child11: {
+          func1: () => 0,
+          nullValue: null, // tslint:disable-line:no-null-keyword
+          undefinedValue: undefined,
+        },
+        number0: 0,
+        number1: 1,
+      },
+      child2: {
+        stringEmpty: '',
+      },
+      func2: () => 1,
+      func3: () => false,
+    });
+
+    expect(mockedService).toEqual({
+      child1: {
+        child11: {
+          func1: jasmine.any(Function),
+        },
+      },
+      child2: {},
+      func2: jasmine.any(Function),
+      func3: jasmine.any(Function),
+    });
+
+    expect(mockedService.child1.child11.func1()).toBeUndefined('func1()');
+    expect(mockedService.func2()).toBeUndefined('func2()');
+    expect(mockedService.func3()).toBeUndefined('func3()');
+  });
+});

--- a/lib/mock-service/mock-service.ts
+++ b/lib/mock-service/mock-service.ts
@@ -1,0 +1,45 @@
+function MockClass(service: any): any {
+  const value: any = {};
+  let prototype = service;
+  while (Object.getPrototypeOf(prototype) !== null) {
+    for (const method of Object.getOwnPropertyNames(prototype)) {
+      if (method === 'constructor') {
+        continue;
+      }
+
+      const descriptor = Object.getOwnPropertyDescriptor(prototype, method);
+      const isGetterSetter = descriptor && (descriptor.get || descriptor.set);
+      if (!isGetterSetter && !value[method]) {
+        value[method] = () => undefined;
+      }
+    }
+    prototype = Object.getPrototypeOf(prototype);
+  }
+  return value;
+}
+
+export function MockService(service: boolean | number | string | null | undefined): undefined;
+export function MockService<T extends {}>(service: T): any;
+export function MockService(service: any): any {
+  // mocking all methods / properties of a class / object.
+  let value: any;
+  if (typeof service === 'function' && service.prototype) {
+    value = MockClass(service.prototype);
+  } else if (typeof service === 'function') {
+    value = () => undefined;
+  } else if (Array.isArray(service)) {
+    value = [];
+  } else if (typeof service === 'object' && service !== null && service.ngMetadataName !== 'InjectionToken') {
+    value = typeof service.constructor === 'function' && service.constructor.prototype
+      ? MockClass(service.constructor.prototype)
+      : {};
+    for (const property of Object.keys(service)) {
+      const mock = MockService(service[property]);
+      if (mock !== undefined) {
+        value[property] = mock;
+      }
+    }
+  }
+
+  return value;
+}


### PR DESCRIPTION
The goal is not to provide an empty object as a provider, but to try to simulate existing methods.

What I tried to do was is to clone https://github.com/gothinkster/angular-realworld-example-app and to add a simple test which checks that app.component is rendered. And found that it fails with the error `TypeError: this.userService.populate is not a function` and I think if we mock at least methods of providers we should solve almost majority of issues except chaining `this.userService.populate().test()` but that's impossible without a metadata parser.

```typescript
import {TestBed} from '@angular/core/testing';
import {BrowserModule} from '@angular/platform-browser';
import {AppRoutingModule} from 'app/app-routing.module';
import {AppComponent} from 'app/app.component';
import {AuthModule} from 'app/auth/auth.module';
import {CoreModule} from 'app/core';
import {HomeModule} from 'app/home/home.module';
import {SharedModule} from 'app/shared';
import {FooterComponent, HeaderComponent} from 'app/shared/layout';
import {MockComponents, MockModule, MockRender} from 'ng-mocks';

describe('test', () => {
  beforeEach(() => {
    TestBed.configureTestingModule({
      imports: [
        MockModule(BrowserModule),
        MockModule(CoreModule),
        MockModule(SharedModule),
        MockModule(HomeModule),
        MockModule(AuthModule),
        MockModule(AppRoutingModule),
      ],
      declarations: [
        ...MockComponents(FooterComponent, HeaderComponent),
        AppComponent,
      ],
    });
  });

  it('it', () => {
    const fixture = MockRender('<app-root></app-root>');
    expect(fixture.debugElement).toBeDefined();
  });
});
```