### PR TITLE
feat: MockBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ All notable changes to this project will be documented in this file. See [standa
 ### Bug Fixes
 
 * **69:** Respect of all parents classes and their methods in mocks
+* `MockRender` won't render anything if a passed component doesn't have a selector.
+* `MockProvider` will return an original provider instead of `undefined` for whitelisted tokens.
+
+### Features
+
+- Added `MockBuilder` ([ISSUE](https://github.com/ike18t/ng-mocks/issues/44))
+- Added `NG_MOCKS` token to get a `Map` of mocks if the `MockBuilder` was used.
+* Added `isNgType` to verify whether a class belongs to a decorator.
+* Added `isNgDef` to verify whether a class decorated by `NgModule`, `Component`, `Directive` or `Pipe`.
+* Added `isNgModuleDefWithProviders` to verify whether an object is `NgModule` with `Providers`.
+* Added `isNgInjectionToken` to verify whether an object is `InjectionToken`.
+* Added `isMockedNgDefOf` to verify whether a class is
+  `MockedModule<T>`, `MockedComponent<T>`, `MockedDirective<T>` or `MockedPipe<T>`.
+* Added `isMockOf` to verify whether an object is an instance of
+  `MockedModule<T>`, `MockedComponent<T>`, `isMockedDirective<T>` or `MockedPipe<T>`.
+* Added `getMockedNgDefOf` returns the mocked version of
+  a module, component, directive or pipe.
+
 
 
 <a name="9.1.0"></a>

--- a/README.md
+++ b/README.md
@@ -7,6 +7,24 @@ Helper function for creating angular mocks for test.
 ## Why use this?
 Sure, you could flip a flag on schema errors to make your component dependencies not matter.  Or you could use this to mock them out and have the ability to assert on their inputs or emit on an output to assert on a side effect.
 
+For an easy start check the [MockBuilder](#MockBuilder) first.
+
+### Sections:
+
+* [MockModule](#mockmodule)
+* [MockComponent](#mockcomponents)
+* [MockDirective](#mockdirectives)
+* [MockPipe](#mockpipes)
+* [MockDeclaration](#mockdeclarations)
+- [MockBuilder](#mockbuilder) - facilitate creation of a mocked environment
+- [MockRender](#mockrender) - facilitate render of components 
+- [MockHelper](#mockhelper) - facilitate extraction of directives of an element
+* [Reactive Forms Components](#mocked-reactive-forms-components)
+* [Structural Components](#usage-example-of-structural-directives)
+* [More examples](#other-examples-of-tests)
+
+---
+
 ## MockComponent(s)
 
 - Mocked component with the same selector
@@ -21,13 +39,13 @@ Sure, you could flip a flag on schema errors to make your component dependencies
     - __simulateTouch - calls `onTouched` on the mocked component bound to a FormControl
 - exportAs support
 
-### Usage Example
+<details><summary>Click to see <strong>a usage example</strong></summary>
+<p>
+
 ```typescript
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { MockComponent, MockedComponent, MockRender } from 'ng-mocks';
-import { DependencyComponent } from './dependency.component';
-import { TestedComponent } from './tested.component';
 
 describe('MockComponent', () => {
   let fixture: ComponentFixture<TestedComponent>;
@@ -101,7 +119,7 @@ describe('MockComponent', () => {
       </dependency-component-selector>
     `);
 
-    // injected ng-content says as it was.
+    // injected ng-content stays as it was.
     const mockedNgContent = localFixture.debugElement
       .query(By.directive(DependencyComponent))
       .nativeElement.innerHTML;
@@ -120,6 +138,11 @@ describe('MockComponent', () => {
 });
 ```
 
+</p>
+</details>
+
+---
+
 ## MockDirective(s)
 
 * Mocked directive with the same selector
@@ -127,13 +150,13 @@ describe('MockComponent', () => {
 * Each directive instance has its own EventEmitter instances for outputs
 * exportAs support
 
-### Usage Example of Attribute Directives
+<details><summary>Click to see <strong>a usage example</strong> of Attribute Directives</summary>
+<p>
+
 ```typescript
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { MockDirective, MockHelper } from 'ng-mocks';
-import { DependencyDirective } from './dependency.directive';
-import { TestedComponent } from './tested.component';
 
 describe('MockDirective', () => {
   let fixture: ComponentFixture<TestedComponent>;
@@ -189,14 +212,18 @@ describe('MockDirective', () => {
   });
 });
 ```
-### Usage Example of Structural Directives
-It's important to render a structural directive first with right context,
+
+</p>
+</details>
+
+<details><summary>Click to see <strong>a usage example</strong> of Structural Directives</summary>
+<p>
+
+It's important to render a structural directive first with the right context,
 when assertions should be done on its nested elements.
 ```typescript
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MockDirective, MockedDirective, MockHelper } from 'ng-mocks';
-import { DependencyDirective } from './dependency.directive';
-import { TestedComponent } from './tested.component';
 
 describe('MockDirective', () => {
   let fixture: ComponentFixture<TestedComponent>;
@@ -243,6 +270,12 @@ describe('MockDirective', () => {
   });
 });
 ```
+
+</p>
+</details>
+
+---
+
 ## MockPipe(s)
 
 * Mocked pipe with the same name.
@@ -251,13 +284,14 @@ describe('MockDirective', () => {
 
 Personally, I found the best thing to do for assertions is to override the transform to write the args so that I can assert on the arguments.
 
-### Usage Example
+
+<details><summary>Click to see <strong>a usage example</strong></summary>
+<p>
+
 ```typescript
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { MockPipe } from 'ng-mocks';
-import { DependencyPipe } from './dependency.pipe';
-import { TestedComponent } from './tested.component';
 
 describe('MockPipe', () => {
   let fixture: ComponentFixture<TestedComponent>;
@@ -284,20 +318,25 @@ describe('MockPipe', () => {
 });
 ```
 
+</p>
+</details>
+
+---
+
 ## Mocked Reactive Forms Components
 
 - Set value on the formControl by calling __simulateChange
 - Set touched on the formControl by calling __simulateTouch
 - Use the `MockedComponent` type to stay typesafe: `MockedComponent<YourReactiveFormComponent>`
 
-### Usage Example
+<details><summary>Click to see <strong>a usage example</strong></summary>
+<p>
+
 ```typescript
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { MockComponent, MockedComponent } from 'ng-mocks';
-import { DependencyComponent } from './dependency.component';
-import { TestedComponent } from './tested.component';
 
 describe('MockReactiveForms', () => {
   let fixture: ComponentFixture<TestedComponent>;
@@ -330,8 +369,16 @@ describe('MockReactiveForms', () => {
 });
 ```
 
+</p>
+</details>
+
+---
+
 ## MockDeclaration(s)
+
 It figures out if it is a component, directive, or pipe and mocks it for you
+
+---
 
 ## MockModule
   * Mocks all components, directives, and pipes using MockDeclaration
@@ -340,12 +387,12 @@ It figures out if it is a component, directive, or pipe and mocks it for you
 
 For providers I typically will use TestBed.get(SomeProvider) and extend it using a library like [ts-mocks](https://www.npmjs.com/package/ts-mocks).
 
-### Usage Example
+<details><summary>Click to see <strong>a usage example</strong></summary>
+<p>
+
 ```typescript
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MockModule } from 'ng-mocks';
-import { DependencyModule } from './dependency.module';
-import { TestedComponent } from './tested.component';
 
 describe('MockModule', () => {
   let fixture: ComponentFixture<TestedComponent>;
@@ -372,17 +419,212 @@ describe('MockModule', () => {
 });
 ```
 
+</p>
+</details>
+
+---
+
+## MockBuilder
+
+The simplest way to mock everything, but not the component for testing is usage of `MockBuilder`.
+Check `examples/MockBuilder/` for real examples. It's useful together with [MockRender](#MockRender).
+
+<details><summary>Click to see <strong>a usage example</strong></summary>
+<p>
+
+```typescript
+import { TestBed } from '@angular/core/testing';
+import { MockBuilder, MockRender } from 'ng-mocks';
+
+describe('MockBuilder:simple', () => {
+  beforeEach(async () => {
+    const ngModule = MockBuilder(MyComponent, MyModule)
+      // mocking configuration here
+      .build();
+    // now ngModule is 
+    // {
+    //   imports: [MockModule(MyModule)], // but MyComponent wasn't mocked for the testing purposes. 
+    // }
+    // and we can simply pass it to the TestBed.
+    return TestBed.configureTestingModule(ngModule).compileComponents();
+  });
+
+  it('should render content ignoring all dependencies', () => {
+    const fixture = MockRender(MyComponent);
+    expect(fixture).toBeDefined();
+    expect(fixture.debugElement.nativeElement.innerHTML).toContain('<div>My Content</div>');
+  });
+});
+```
+
+</p>
+</details>
+
+<details><summary>Click to see <strong>a detailed information</strong></summary>
+<p>
+
+```typescript
+import { MockBuilder } from 'ng-mocks';
+
+// Mocks everything in MyModule (imports, declarations, providers)
+// but keeps MyComponent as it is.
+const ngModule = MockBuilder(MyComponent, MyModule).build();
+
+// The same as code above.
+const ngModule = MockBuilder().keep(MyComponent, {export: true}).mock(MyModule).build();
+
+// If we want to keep a module, component, directive, pipe or provider as it is (not mocking).
+// We should use .keep.
+const ngModule = MockBuilder(MyComponent, MyModule)
+  .keep(SomeModule)
+  .keep(SomeComponent)
+  .keep(SomeDirective)
+  .keep(SomePipe)
+  .keep(SomeDependency)
+  .keep(SomeInjectionToken)
+  .build()
+;
+
+// If we want to mock something, even a part of a kept module we should use .mock.
+const ngModule = MockBuilder(MyComponent, MyModule)
+  .mock(SomeModule)
+  .mock(SomeComponent)
+  .mock(SomeDirective)
+  .mock(SomePipe)
+  .mock(SomeDependency)
+  .mock(SomeInjectionToken)
+  .build()
+;
+
+// If we want to replace something with something we should use .replace.
+// The replacement has to be decorated with the same decorator as the source.
+// It's impossible to replace a provider or a service, we should use .provide or .mock for that.
+const ngModule = MockBuilder(MyComponent, MyModule)
+  .replace(HttpClientModule, HttpClientTestingModule)
+  .replace(SomeComponent, SomeOtherComponent)
+  .replace(SomeDirective, SomeOtherDirective)
+  .replace(SomePipe, SomeOtherPipe)
+  .build()
+;
+
+// For pipes we can set its handler as the 2nd parameter of .mock too.
+const ngModule = MockBuilder(MyComponent, MyModule)
+  .mock(SomePipe, (value) => 'My Custom Content')
+  .build()
+;
+
+// If we want to add or replace a provider or a service we should use .provide.
+// It has the same interface as a regular provider.
+const ngModule = MockBuilder(MyComponent, MyModule)
+  .provide(MyService)
+  .provide([SomeService1, SomeService2])
+  .provide({provide: SomeComponent3, useValue: anything1})
+  .provide({provide: SOME_TOKEN, useFactory: () => anything2})
+  .build()
+;
+
+// If we need to mock, or to use useValue we can use .mock for that.
+const ngModule = MockBuilder(MyComponent, MyModule)
+  .mock(MyService)
+  .mock(SomeService1)
+  .mock(SomeService2)
+  .mock(SomeComponent3, anything1)
+  .mock(SOME_TOKEN, anything2)
+  .build()
+;
+
+// Anytime we can change our decision.
+// The last action on the same object wins.
+const ngModule = MockBuilder(MyComponent, MyModule)
+  .keep(SomeModule)
+  .mock(SomeModule)
+  .keep(SomeModule)
+  .mock(SomeModule)
+  .build()
+;
+
+// If we want to test a component, directive or pipe which wasn't exported
+// we should mark it as an 'export'.
+// Doesn't matter how deep it is. It will be exported to the level of TestingModule.
+const ngModule = MockBuilder(MyComponent, MyModule)
+  .keep(SomeModuleComponentDirectivePipeProvider1, {
+    export: true,
+  })
+  .build()
+;
+
+// By default all definitions (kept and mocked) are added to the TestingModule
+// if they are not dependency of another definition.
+// Modules are added as imports to the TestingModule.
+// Components, Directive, Pipes are added as declarations to the TestingModule.
+// Providers and Services are added as providers to the TestingModule.
+// If we don't want something to be added to the TestingModule at all
+// we should mark it as a 'dependency'.
+const ngModule = MockBuilder(MyComponent, MyModule)
+  .keep(SomeModuleComponentDirectivePipeProvider1, {
+    dependency: true,
+  })
+  .mock(SomeModuleComponentDirectivePipeProvider1, {
+    dependency: true,
+  })
+  .replace(SomeModuleComponentDirectivePipeProvider1, anything1, {
+    dependency: true,
+  })
+  .build()
+;
+
+// Imagine we want to render a structural directive by default.
+// Now we can do that via adding a 'render' flag in its config.
+const ngModule = MockBuilder(MyComponent, MyModule)
+  .mock(MyDirective, {
+    render: true,
+  })
+  .build()
+;
+
+// Imagine the directive has own context and variables.
+// Then instead of flag we can set its context.
+const ngModule = MockBuilder(MyComponent, MyModule)
+  .mock(MyDirective, {
+    render: {
+      $implicit: something1,
+      variables: {something2: something3}
+    },
+  })
+  .build()
+;
+
+// If we use ContentChild in a component and we want to render it by default too
+// we should use its id for that in the same way as for a mocked directive.
+const ngModule = MockBuilder(MyComponent, MyModule)
+  .mock(MyDirective, {
+    render: {
+      blockId: true,
+      blockWithContext: {
+        $implicit: something1,
+        variables: {something2: something3}
+      },
+    },
+  })
+  .build()
+;
+```
+
+</p>
+</details>
+
+---
+
 ## MockRender
 Providers simple way to render anything, change `@Inputs` and `@Outputs` of testing component, directives etc.
 
-### Usage Example
+<details><summary>Click to see <strong>a usage example</strong></summary>
+<p>
+
 ```typescript
 import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { MockModule, MockRender } from 'ng-mocks';
-
-import { DependencyModule } from './dependency.module';
-import { TestedComponent } from './tested.component';
 
 describe('MockRender', () => {
 
@@ -444,7 +686,13 @@ describe('MockRender', () => {
 });
 ```
 
+</p>
+</details>
+
+---
+
 ## MockHelper
+
 MockHelper provides 3 methods to get attribute and structural directives from an element. 
 
 `MockHelper.getDirective(fixture.debugElement, Directive)` -
@@ -456,12 +704,17 @@ returns first found attribute or structural directive which belongs to current e
 `MockHelper.findDirectives(fixture.debugElement, Directive)`
 returns all found attribute or structural directives which belong to current element and all its child.
 
+---
+
 ## Other examples of tests
+
 More detailed examples can be found in
 [e2e](https://github.com/ike18t/ng-mocks/tree/master/e2e)
 and in
 [examples](https://github.com/ike18t/ng-mocks/tree/master/examples)
 directories in the repo.
+
+---
 
 ## Find an issue or have a request?
 Report it as an issue or submit a PR.  I'm open to contributions.

--- a/e2e/exports-only/fixtures.components.ts
+++ b/e2e/exports-only/fixtures.components.ts
@@ -1,0 +1,10 @@
+// tslint:disable:max-classes-per-file
+
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'internal-component',
+  template: 'internal',
+})
+export class InternalComponent {
+}

--- a/e2e/exports-only/fixtures.modules.ts
+++ b/e2e/exports-only/fixtures.modules.ts
@@ -1,0 +1,28 @@
+// tslint:disable:max-classes-per-file
+
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+
+import { InternalComponent } from './fixtures.components';
+
+@NgModule({
+  declarations: [
+    InternalComponent,
+  ],
+  exports: [
+    InternalComponent,
+  ],
+  imports: [
+    CommonModule,
+  ],
+})
+export class InternalModule {
+}
+
+@NgModule({
+  exports: [
+    InternalModule,
+  ],
+})
+export class TargetModule {
+}

--- a/e2e/exports-only/test.spec.ts
+++ b/e2e/exports-only/test.spec.ts
@@ -1,0 +1,66 @@
+import { TestBed } from '@angular/core/testing';
+import { MockBuilder, MockRender } from 'ng-mocks';
+
+import { InternalComponent } from './fixtures.components';
+import { TargetModule } from './fixtures.modules';
+
+describe('ExportsOnly:real', () => {
+  beforeEach(async (done) => {
+    await TestBed.configureTestingModule({
+      imports: [TargetModule],
+    }).compileComponents();
+    done();
+  });
+
+  it('should render', () => {
+    const fixture = MockRender(InternalComponent);
+    expect(fixture).toBeDefined();
+    expect(fixture.debugElement.nativeElement.innerHTML)
+      .toContain('<internal-component>internal</internal-component>');
+  });
+});
+
+describe('ExportsOnly:mock1', () => {
+  beforeEach(async (done) => {
+    await MockBuilder().mock(TargetModule);
+    done();
+  });
+
+  // The expectation is to see that InternalModule was exported and it can be accessed from the test.
+  it('should render', () => {
+    const fixture = MockRender(InternalComponent);
+    expect(fixture).toBeDefined();
+    const content = fixture.debugElement.nativeElement.innerHTML;
+    expect(content).toEqual('<internal-component></internal-component>');
+  });
+});
+
+describe('ExportsOnly:mock2', () => {
+  beforeEach(async (done) => {
+    await MockBuilder().mock(TargetModule).mock(InternalComponent);
+    done();
+  });
+
+  // The expectation is to see that InternalModule was exported and it can be accessed from the test.
+  it('should render', () => {
+    const fixture = MockRender(InternalComponent);
+    expect(fixture).toBeDefined();
+    const content = fixture.debugElement.nativeElement.innerHTML;
+    expect(content).toEqual('<internal-component></internal-component>');
+  });
+});
+
+describe('ExportsOnly:mock3', () => {
+  beforeEach(async (done) => {
+    await MockBuilder().keep(TargetModule);
+    done();
+  });
+
+  // The expectation is to see that InternalModule was exported and it can be accessed from the test.
+  it('should render', () => {
+    const fixture = MockRender(InternalComponent);
+    expect(fixture).toBeDefined();
+    expect(fixture.debugElement.nativeElement.innerHTML)
+      .toContain('<internal-component>internal</internal-component>');
+  });
+});

--- a/e2e/internal-only-nested/fixtures.components.ts
+++ b/e2e/internal-only-nested/fixtures.components.ts
@@ -1,0 +1,10 @@
+// tslint:disable:max-classes-per-file
+
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'internal-component',
+  template: 'internal',
+})
+export class InternalComponent {
+}

--- a/e2e/internal-only-nested/fixtures.modules.ts
+++ b/e2e/internal-only-nested/fixtures.modules.ts
@@ -1,0 +1,38 @@
+// tslint:disable:max-classes-per-file
+
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+
+import { InternalComponent } from './fixtures.components';
+
+@NgModule({
+  declarations: [
+    InternalComponent,
+  ],
+  imports: [
+    CommonModule,
+  ],
+})
+export class Nested1Module {}
+
+@NgModule({
+  imports: [
+    Nested1Module,
+  ],
+})
+export class Nested2Module {}
+
+@NgModule({
+  imports: [
+    Nested1Module,
+  ],
+})
+export class Nested3Module {}
+
+@NgModule({
+  imports: [
+    Nested2Module,
+    Nested3Module,
+  ],
+})
+export class TargetModule {}

--- a/e2e/internal-only-nested/test.spec.ts
+++ b/e2e/internal-only-nested/test.spec.ts
@@ -1,0 +1,39 @@
+import { TestBed } from '@angular/core/testing';
+import { MockBuilder, MockRender } from 'ng-mocks';
+
+import { InternalComponent } from './fixtures.components';
+import { TargetModule } from './fixtures.modules';
+
+describe('InternalOnlyNested:real', () => {
+  beforeEach(async (done) => {
+    await TestBed.configureTestingModule({
+      imports: [TargetModule],
+    }).compileComponents();
+    done();
+  });
+
+  it('should render', () => {
+    try {
+      MockRender(InternalComponent);
+      fail('should fail on the internal component');
+    } catch (e) {
+      expect(e).toEqual(jasmine.objectContaining({ngSyntaxError: true}));
+    }
+  });
+});
+
+describe('InternalOnlyNested:mock', () => {
+  beforeEach(async (done) => {
+    await MockBuilder().mock(TargetModule).mock(InternalComponent, {export: true});
+    done();
+  });
+
+  // The expectation is to see that InternalComponent was exported to the level of the TestingModule
+  // and can be accessed in the test even it was deeply nested.
+  it('should render', () => {
+    const fixture = MockRender(InternalComponent);
+    expect(fixture).toBeDefined();
+    const content = fixture.debugElement.nativeElement.innerHTML;
+    expect(content).toEqual('<internal-component></internal-component>');
+  });
+});

--- a/e2e/internal-only/fixtures.components.ts
+++ b/e2e/internal-only/fixtures.components.ts
@@ -1,0 +1,10 @@
+// tslint:disable:max-classes-per-file
+
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'internal-component',
+  template: 'internal',
+})
+export class InternalComponent {
+}

--- a/e2e/internal-only/fixtures.modules.ts
+++ b/e2e/internal-only/fixtures.modules.ts
@@ -1,0 +1,16 @@
+// tslint:disable:max-classes-per-file
+
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+
+import { InternalComponent } from './fixtures.components';
+
+@NgModule({
+  declarations: [
+    InternalComponent,
+  ],
+  imports: [
+    CommonModule,
+  ],
+})
+export class TargetModule {}

--- a/e2e/internal-only/test.spec.ts
+++ b/e2e/internal-only/test.spec.ts
@@ -1,0 +1,38 @@
+import { TestBed } from '@angular/core/testing';
+import { MockBuilder, MockRender } from 'ng-mocks';
+
+import { InternalComponent } from './fixtures.components';
+import { TargetModule } from './fixtures.modules';
+
+describe('InternalOnly:real', () => {
+  beforeEach(async (done) => {
+    await TestBed.configureTestingModule({
+      imports: [TargetModule],
+    }).compileComponents();
+    done();
+  });
+
+  it('should render', () => {
+    try {
+      MockRender(InternalComponent);
+      fail('should fail on the internal component');
+    } catch (e) {
+      expect(e).toEqual(jasmine.objectContaining({ngSyntaxError: true}));
+    }
+  });
+});
+
+describe('InternalOnly:mock', () => {
+  beforeEach(async (done) => {
+    await MockBuilder().mock(TargetModule).mock(InternalComponent, {export: true});
+    done();
+  });
+
+  // The expectation is to see that InternalComponent was exported and can be accessed from the test.
+  it('should render', () => {
+    const fixture = MockRender(InternalComponent);
+    expect(fixture).toBeDefined();
+    const content = fixture.debugElement.nativeElement.innerHTML;
+    expect(content).toEqual('<internal-component></internal-component>');
+  });
+});

--- a/e2e/internal-vs-external/fixtures.components.ts
+++ b/e2e/internal-vs-external/fixtures.components.ts
@@ -1,0 +1,17 @@
+// tslint:disable:max-classes-per-file
+
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'internal-component',
+  template: 'internal',
+})
+export class InternalComponent {
+}
+
+@Component({
+  selector: 'external-component',
+  template: 'external <internal-component></internal-component>',
+})
+export class ExternalComponent {
+}

--- a/e2e/internal-vs-external/fixtures.modules.ts
+++ b/e2e/internal-vs-external/fixtures.modules.ts
@@ -1,0 +1,20 @@
+// tslint:disable:max-classes-per-file
+
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+
+import { ExternalComponent, InternalComponent } from './fixtures.components';
+
+@NgModule({
+  declarations: [
+    InternalComponent,
+    ExternalComponent,
+  ],
+  exports: [
+    ExternalComponent,
+  ],
+  imports: [
+    CommonModule,
+  ],
+})
+export class TargetModule {}

--- a/e2e/internal-vs-external/test.spec.ts
+++ b/e2e/internal-vs-external/test.spec.ts
@@ -1,0 +1,74 @@
+import { TestBed } from '@angular/core/testing';
+import { MockBuilder, MockModule, MockRender } from 'ng-mocks';
+
+import { ExternalComponent, InternalComponent } from './fixtures.components';
+import { TargetModule } from './fixtures.modules';
+
+describe('InternalVsExternal:real', () => {
+  beforeEach(async (done) => {
+    await TestBed.configureTestingModule({
+      imports: [TargetModule],
+    }).compileComponents();
+    done();
+  });
+
+  it('should render', () => {
+    const fixture = MockRender(ExternalComponent);
+    expect(fixture).toBeDefined();
+    const content = fixture.debugElement.nativeElement.innerHTML;
+    expect(content).toContain('external <internal-component>internal</internal-component>');
+
+    try {
+      MockRender(InternalComponent);
+      fail('should fail on the internal component');
+    } catch (e) {
+      expect(e).toEqual(jasmine.objectContaining({ngSyntaxError: true}));
+    }
+  });
+});
+
+describe('InternalVsExternal:mock', () => {
+  beforeEach(async (done) => {
+    await MockBuilder().mock(TargetModule);
+    done();
+  });
+
+  // The expectation is to see that ExternalComponent was exported and InternalComponent wasn't.
+  it('should render', () => {
+    const fixture = MockRender(ExternalComponent);
+    expect(fixture).toBeDefined();
+    const content = fixture.debugElement.nativeElement.innerHTML;
+    expect(content).toEqual('<external-component></external-component>');
+
+    try {
+      MockRender(InternalComponent);
+      fail('should fail on the internal component');
+    } catch (e) {
+      expect(e).toEqual(jasmine.objectContaining({ngSyntaxError: true}));
+    }
+  });
+});
+
+describe('InternalVsExternal:legacy', () => {
+  beforeEach(async (done) => {
+    await TestBed.configureTestingModule({
+      imports: [MockModule(TargetModule)],
+    }).compileComponents();
+    done();
+  });
+
+  it('should render', () => {
+    const fixture = MockRender(ExternalComponent);
+    expect(fixture).toBeDefined();
+    const content = fixture.debugElement.nativeElement.innerHTML;
+    expect(content).toEqual('<external-component></external-component>');
+
+    // the code below will fail because the MockModule outside of the MockBuilder exports everything.
+    // try {
+    //   MockRender(InternalComponent);
+    //   fail('should fail on the internal component');
+    // } catch (e) {
+    //   expect(e).toEqual(jasmine.objectContaining({ngSyntaxError: true}));
+    // }
+  });
+});

--- a/e2e/mock-builder-by-directive/fixtures.components.ts
+++ b/e2e/mock-builder-by-directive/fixtures.components.ts
@@ -1,0 +1,10 @@
+// tslint:disable:max-classes-per-file
+
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'internal-component',
+  template: 'internal',
+})
+export class InternalComponent {
+}

--- a/e2e/mock-builder-by-directive/fixtures.modules.ts
+++ b/e2e/mock-builder-by-directive/fixtures.modules.ts
@@ -1,0 +1,15 @@
+// tslint:disable:max-classes-per-file
+
+import { NgModule } from '@angular/core';
+
+import { InternalComponent } from './fixtures.components';
+
+@NgModule({
+  declarations: [
+    InternalComponent,
+  ],
+  exports: [
+    InternalComponent,
+  ],
+})
+export class TargetModule {}

--- a/e2e/mock-builder-by-directive/test.spec.ts
+++ b/e2e/mock-builder-by-directive/test.spec.ts
@@ -1,0 +1,40 @@
+import { TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { MockBuilder, MockComponent, MockRender } from 'ng-mocks';
+
+import { InternalComponent } from './fixtures.components';
+import { TargetModule } from './fixtures.modules';
+
+describe('MockBuilderByDirective:real', () => {
+  beforeEach(async (done) => {
+    await TestBed.configureTestingModule({
+      imports: [TargetModule],
+    }).compileComponents();
+    done();
+  });
+
+  it('should render', () => {
+    const fixture = MockRender(InternalComponent);
+    const element = fixture.debugElement.query(By.directive(InternalComponent));
+    expect(element).toBeDefined();
+  });
+});
+
+describe('MockBuilderByDirective:mock', () => {
+  beforeEach(async (done) => {
+    await MockBuilder().mock(TargetModule);
+    done();
+  });
+
+  it('should find mock', () => {
+    const fixture = MockRender(InternalComponent);
+    const element = fixture.debugElement.query(By.directive(MockComponent(InternalComponent)));
+    expect(element).toBeDefined();
+  });
+
+  it('should find original', () => {
+    const fixture = MockRender(InternalComponent);
+    const element = fixture.debugElement.query(By.directive(InternalComponent));
+    expect(element).toBeDefined();
+  });
+});

--- a/e2e/nested-before-each/fixtures.components.ts
+++ b/e2e/nested-before-each/fixtures.components.ts
@@ -1,0 +1,10 @@
+// tslint:disable:max-classes-per-file
+
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'internal-component',
+  template: 'internal',
+})
+export class InternalComponent {
+}

--- a/e2e/nested-before-each/fixtures.modules.ts
+++ b/e2e/nested-before-each/fixtures.modules.ts
@@ -1,0 +1,15 @@
+// tslint:disable:max-classes-per-file
+
+import { NgModule } from '@angular/core';
+
+import { InternalComponent } from './fixtures.components';
+
+@NgModule({
+  declarations: [
+    InternalComponent,
+  ],
+  exports: [
+    InternalComponent,
+  ],
+})
+export class TargetModule {}

--- a/e2e/nested-before-each/test.spec.ts
+++ b/e2e/nested-before-each/test.spec.ts
@@ -1,0 +1,77 @@
+import { Type } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { MockComponent } from 'ng-mocks';
+
+import { InternalComponent } from './fixtures.components';
+
+describe('nested-before-each', () => {
+  let level = 0;
+  let mock: Type<any>;
+
+  beforeEach(() => {
+    level = 0;
+    mock = MockComponent(InternalComponent);
+    TestBed.configureTestingModule({
+      declarations: [mock],
+    });
+    return TestBed.compileComponents();
+  });
+
+  describe('tested', () => {
+    beforeEach(() => {
+      level += 1;
+    });
+
+    describe('tested', () => {
+      beforeEach(() => {
+        level += 1;
+      });
+
+      it('should have the same mock after the first run', () => {
+        expect(level).toBeGreaterThan(0);
+        expect(MockComponent(InternalComponent)).toBe(mock);
+      });
+
+      it('should have the same mock after the second run', () => {
+        expect(level).toBeGreaterThan(0);
+        expect(MockComponent(InternalComponent)).toBe(mock);
+      });
+    });
+  });
+});
+
+describe('nested-before-all', () => {
+  let level = 0;
+  let mock: Type<any>;
+
+  beforeAll(() => {
+    level = 0;
+    mock = MockComponent(InternalComponent);
+    TestBed.configureTestingModule({
+      declarations: [mock],
+    });
+    return TestBed.compileComponents();
+  });
+
+  describe('tested', () => {
+    beforeEach(() => {
+      level += 1;
+    });
+
+    describe('tested', () => {
+      beforeEach(() => {
+        level += 1;
+      });
+
+      it('should have the same mock after the first run', () => {
+        expect(level).toBeGreaterThan(0);
+        expect(MockComponent(InternalComponent)).toBe(mock);
+      });
+
+      it('should have the same mock after the second run', () => {
+        expect(level).toBeGreaterThan(0);
+        expect(MockComponent(InternalComponent)).toBe(mock);
+      });
+    });
+  });
+});

--- a/e2e/on-push/on-push.spec.ts
+++ b/e2e/on-push/on-push.spec.ts
@@ -66,12 +66,15 @@ describe('ChangeDetectionStrategy.OnPush:mock', () => {
   let fixture: ComponentFixture<ItemListComponent>;
   let component: ItemListComponent;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    // console.log((TestBed as any)._instantiated);
     TestBed.configureTestingModule({
       declarations: [
         ItemListComponent,
       ],
     });
+    await TestBed.compileComponents();
+    // console.log((TestBed as any)._instantiated);
 
     fixture = MockRender(ItemListComponent, {
       items: [],

--- a/e2e/provider-with-dependency/fixtures.components.ts
+++ b/e2e/provider-with-dependency/fixtures.components.ts
@@ -1,0 +1,16 @@
+// tslint:disable:max-classes-per-file
+
+import { Component } from '@angular/core';
+import { ServiceChild } from './fixtures.services';
+
+@Component({
+  selector: 'internal-component',
+  template: '{{ child.parent.echo() }}',
+})
+export class InternalComponent {
+  public readonly child: ServiceChild;
+
+  constructor(child: ServiceChild) {
+    this.child = child;
+  }
+}

--- a/e2e/provider-with-dependency/fixtures.modules.ts
+++ b/e2e/provider-with-dependency/fixtures.modules.ts
@@ -1,0 +1,25 @@
+// tslint:disable:max-classes-per-file
+
+import { NgModule } from '@angular/core';
+
+import { InternalComponent } from './fixtures.components';
+import { ServiceChild, ServiceParent, ServiceReplacedParent } from './fixtures.services';
+
+@NgModule({
+  declarations: [
+    InternalComponent,
+  ],
+  exports: [
+    InternalComponent,
+  ],
+  providers: [
+    ServiceParent,
+    ServiceReplacedParent,
+    {
+      deps: [ServiceReplacedParent],
+      provide: ServiceChild,
+      useFactory: (parent: ServiceParent) => new ServiceChild(parent),
+    },
+  ],
+})
+export class TargetModule {}

--- a/e2e/provider-with-dependency/fixtures.services.ts
+++ b/e2e/provider-with-dependency/fixtures.services.ts
@@ -1,0 +1,26 @@
+// tslint:disable:max-classes-per-file
+
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class ServiceParent {
+  protected value = 'parent';
+
+  public echo() {
+    return this.value;
+  }
+}
+
+@Injectable()
+export class ServiceReplacedParent extends ServiceParent {
+  protected value = 'replaced';
+}
+
+@Injectable()
+export class ServiceChild {
+  public readonly parent: ServiceParent;
+
+  constructor(parent: ServiceParent) {
+    this.parent = parent;
+  }
+}

--- a/e2e/provider-with-dependency/test.spec.ts
+++ b/e2e/provider-with-dependency/test.spec.ts
@@ -1,0 +1,66 @@
+import { Injectable } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { MockBuilder, MockRender } from 'ng-mocks';
+
+import { InternalComponent } from './fixtures.components';
+import { TargetModule } from './fixtures.modules';
+import { ServiceReplacedParent } from './fixtures.services';
+
+@Injectable()
+class ServiceMock {
+  protected value = 'mock';
+
+  public echo() {
+    return this.value;
+  }
+}
+
+describe('provider-with-dependency:real', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TargetModule],
+    });
+    return TestBed.compileComponents();
+  });
+
+  it('should render "parent"', () => {
+    const fixture = MockRender(InternalComponent);
+    expect(fixture.debugElement.nativeElement.innerHTML).toEqual('<internal-component>replaced</internal-component>');
+  });
+});
+
+describe('provider-with-dependency:provided', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TargetModule],
+      providers: [
+        {
+          provide: ServiceReplacedParent,
+          useClass: ServiceMock,
+        }
+      ],
+    });
+    return TestBed.compileComponents();
+  });
+
+  it('should render "parent"', () => {
+    const fixture = MockRender(InternalComponent);
+    expect(fixture.debugElement.nativeElement.innerHTML).toEqual('<internal-component>mock</internal-component>');
+  });
+});
+
+describe('provider-with-dependency:mock', () => {
+  beforeEach(() => {
+    const ngModule = MockBuilder().keep(TargetModule).provide({
+      provide: ServiceReplacedParent,
+      useClass: ServiceMock,
+    }).build();
+    TestBed.configureTestingModule(ngModule);
+    return TestBed.compileComponents();
+  });
+
+  it('should render "parent" even the providers where patched', () => {
+    const fixture = MockRender(InternalComponent);
+    expect(fixture.debugElement.nativeElement.innerHTML).toEqual('<internal-component>mock</internal-component>');
+  });
+});

--- a/e2e/rerender-rendered-content-child/fixtures.components.ts
+++ b/e2e/rerender-rendered-content-child/fixtures.components.ts
@@ -1,0 +1,12 @@
+// tslint:disable:max-classes-per-file
+
+import { Component, ContentChild, TemplateRef } from '@angular/core';
+import { staticFalse } from '../../tests';
+
+@Component({
+  selector: 'ccc',
+  template: `<ng-template ngFor [ngForOf]="[]" [ngForTemplate]="injectedBlock"></ng-template>`,
+})
+export class ContentChildComponent {
+  @ContentChild('block', {...staticFalse}) injectedBlock: TemplateRef<any>;
+}

--- a/e2e/rerender-rendered-content-child/fixtures.module.ts
+++ b/e2e/rerender-rendered-content-child/fixtures.module.ts
@@ -1,0 +1,14 @@
+// tslint:disable:max-classes-per-file
+
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+
+import { ContentChildComponent } from './fixtures.components';
+
+@NgModule({
+  declarations: [ContentChildComponent],
+  exports: [ContentChildComponent],
+  imports: [CommonModule],
+})
+export class ContentChildModule {
+}

--- a/e2e/rerender-rendered-content-child/test.spec.ts
+++ b/e2e/rerender-rendered-content-child/test.spec.ts
@@ -1,0 +1,43 @@
+import { By } from '@angular/platform-browser';
+import { MockBuilder, MockedComponent, MockRender } from 'ng-mocks';
+
+import { ContentChildComponent } from './fixtures.components';
+
+describe('Rerender of a rendered @ContentChild', () => {
+  beforeEach(async (done: DoneFn) => {
+    await MockBuilder()
+      .mock(ContentChildComponent, {
+        render: {
+          block: {
+            $implicit: '$implicit',
+          }
+        }
+      });
+    done();
+  });
+
+  it('should rerender everything correctly', () => {
+    const fixture = MockRender(`<ccc>
+        <ng-template #block let-value>{{ value }} {{ outside }}</ng-template>
+    </ccc>`, {
+      outside: '1',
+    });
+    expect(fixture).toBeDefined();
+    expect(fixture.debugElement.nativeElement.innerText).toContain('$implicit 1');
+
+    fixture.componentInstance.outside = '2';
+    fixture.detectChanges();
+    expect(fixture.debugElement.nativeElement.innerText).toContain('$implicit 2');
+
+    const component = fixture.debugElement.query(By.directive(ContentChildComponent))
+      .componentInstance as MockedComponent<ContentChildComponent>;
+
+    component.__render('block', 'updated');
+    fixture.detectChanges();
+    expect(fixture.debugElement.nativeElement.innerText).toContain('updated 2');
+
+    fixture.componentInstance.outside = '3';
+    fixture.detectChanges();
+    expect(fixture.debugElement.nativeElement.innerText).toContain('updated 3');
+  });
+});

--- a/e2e/shared-mocked-module/fixtures.components.ts
+++ b/e2e/shared-mocked-module/fixtures.components.ts
@@ -1,0 +1,31 @@
+// tslint:disable:max-classes-per-file
+
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'my-component',
+  template: 'real content',
+})
+export class MyComponent {
+}
+
+@Component({
+  selector: 'child-1-component',
+  template: 'child:1 <my-component></my-component>',
+})
+export class Child1Component {
+}
+
+@Component({
+  selector: 'child-2-component',
+  template: 'child:2 <my-component></my-component>',
+})
+export class Child2Component {
+}
+
+@Component({
+  selector: 'target-component',
+  template: '<child-1-component></child-1-component> - <child-2-component></child-2-component>',
+})
+export class TargetComponent {
+}

--- a/e2e/shared-mocked-module/fixtures.modules.ts
+++ b/e2e/shared-mocked-module/fixtures.modules.ts
@@ -1,0 +1,57 @@
+// tslint:disable:max-classes-per-file
+
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+
+import { Child1Component, Child2Component, MyComponent, TargetComponent } from './fixtures.components';
+
+@NgModule({
+  declarations: [
+    MyComponent,
+  ],
+  exports: [
+    MyComponent,
+  ],
+})
+export class MyModule {}
+
+@NgModule({
+  declarations: [
+    Child1Component,
+  ],
+  exports: [
+    Child1Component,
+  ],
+  imports: [
+    MyModule,
+  ],
+})
+export class Child1Module {}
+
+@NgModule({
+  declarations: [
+    Child2Component,
+  ],
+  exports: [
+    Child2Component,
+  ],
+  imports: [
+    MyModule,
+  ],
+})
+export class Child2Module {}
+
+@NgModule({
+  declarations: [
+    TargetComponent,
+  ],
+  exports: [
+    TargetComponent,
+  ],
+  imports: [
+    CommonModule,
+    Child1Module,
+    Child2Module,
+  ],
+})
+export class TargetModule {}

--- a/e2e/shared-mocked-module/test.spec.ts
+++ b/e2e/shared-mocked-module/test.spec.ts
@@ -1,0 +1,47 @@
+import { TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { MockBuilder, MockedComponent, MockRender } from 'ng-mocks';
+
+import { MyComponent, TargetComponent } from './fixtures.components';
+import { TargetModule } from './fixtures.modules';
+
+describe('SharedMockedModule:real', () => {
+  beforeEach(async (done) => {
+    await TestBed.configureTestingModule({
+      imports: [TargetModule],
+    }).compileComponents();
+    done();
+  });
+
+  it('should render', () => {
+    const fixture = MockRender(TargetComponent);
+    expect(fixture).toBeDefined();
+    const content = fixture.debugElement.nativeElement.innerHTML;
+    expect(content)
+      .toContain('<child-1-component>child:1 <my-component>real content</my-component></child-1-component>');
+    expect(content)
+      .toContain('<child-2-component>child:2 <my-component>real content</my-component></child-2-component>');
+  });
+});
+
+describe('SharedMockedModule:mock', () => {
+  beforeEach(async (done) => {
+    await MockBuilder(TargetComponent)
+      .keep(TargetModule)
+      .mock(MyComponent)
+    ;
+    done();
+  });
+
+  // The expectation is to verify that only MyComponent was mocked, even it was deeply nested.
+  it('should render', () => {
+    const fixture = MockRender(TargetComponent);
+    expect(fixture).toBeDefined();
+    const content = fixture.debugElement.nativeElement.innerHTML;
+    const component = fixture.debugElement.query(By.directive(MyComponent))
+      .componentInstance as MockedComponent<MyComponent>;
+    expect(component).toBeDefined();
+    expect(content).toContain('<child-1-component>child:1 <my-component></my-component></child-1-component>');
+    expect(content).toContain('<child-2-component>child:2 <my-component></my-component></child-2-component>');
+  });
+});

--- a/examples/MockBuilder/MockBuilder.spec.ts
+++ b/examples/MockBuilder/MockBuilder.spec.ts
@@ -1,0 +1,225 @@
+import { HttpBackend, HttpClientModule } from '@angular/common/http';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { inject, TestBed } from '@angular/core/testing';
+import { MockBuilder, MockRender } from 'ng-mocks';
+
+import {
+  ComponentContentChild,
+  ComponentWeDontWantToMock,
+  ComponentWeWantToMock,
+  MyComponent,
+  MyComponent1,
+  MyComponent2,
+  MyComponent3,
+} from './fixtures.components';
+import { DirectiveWeDontWantToMock, DirectiveWeWantToMock, MyDirective } from './fixtures.directives';
+import { ModuleWeDontWantToMock, ModuleWeWantToMockBesidesMyModule, MyModule } from './fixtures.modules';
+import {
+  MyPipe,
+  PipeWeDontWantToMock,
+  PipeWeWantToCustomize,
+  PipeWeWantToMock,
+  PipeWeWantToRestore,
+} from './fixtures.pipes';
+import {
+  AnythingWeWant1,
+  AnythingWeWant2,
+  MyCustomProvider1,
+  MyCustomProvider2,
+  MyCustomProvider3,
+  MyService1,
+  MyService2,
+  ServiceWeDontWantToMock,
+  ServiceWeWantToCustomize,
+  ServiceWeWantToMock,
+  TheSameAsAnyProvider,
+} from './fixtures.services';
+import {
+  INJECTION_TOKEN_WE_DONT_WANT_TO_MOCK,
+  INJECTION_TOKEN_WE_WANT_TO_CUSTOMIZE,
+  INJECTION_TOKEN_WE_WANT_TO_MOCK,
+} from './fixtures.tokens';
+
+describe('MockBuilder:simple', () => {
+  beforeEach(async () => {
+    const ngModule = MockBuilder(MyComponent, MyModule)
+      // mocking configuration here
+      .build();
+
+    // now ngModule is
+    // {
+    //   imports: [MockModule(MyModule)], // but MyComponent wasn't mocked for the testing purposes.
+    // }
+    // and we can simply pass it to the TestBed.
+    return TestBed.configureTestingModule(ngModule).compileComponents();
+  });
+
+  it('should render content ignoring all dependencies', () => {
+    const fixture = MockRender(MyComponent);
+    expect(fixture).toBeDefined();
+    expect(fixture.debugElement.nativeElement.innerHTML).toContain('<div>My Content</div>');
+  });
+});
+
+describe('MockBuilder:deep', () => {
+  beforeEach(async () => {
+    const ngModule = MockBuilder(MyComponent, MyModule)
+
+      .mock(ComponentContentChild, {
+        render: {
+          block: {
+            $implicit: '-$implicit-',
+            variables: {a: {z: 'b'}},
+          },
+        },
+      })
+
+      .keep(ModuleWeDontWantToMock, {
+        dependency: true,
+      })
+      .keep(ComponentWeDontWantToMock, {
+        dependency: true,
+      })
+      .keep(DirectiveWeDontWantToMock, {
+        dependency: true,
+      })
+      .keep(PipeWeDontWantToMock, {
+        dependency: true,
+      })
+      .keep(ServiceWeDontWantToMock)
+      .keep(INJECTION_TOKEN_WE_DONT_WANT_TO_MOCK)
+
+      // The same can be done with Components, Directives and Pipes.
+      // For Providers use .provider() or .mock().
+      .replace(HttpClientModule, HttpClientTestingModule, {
+        dependency: true,
+      })
+
+      .mock(ModuleWeWantToMockBesidesMyModule, {
+        dependency: true,
+      })
+      .mock(ComponentWeWantToMock, {
+        dependency: true,
+      })
+      .mock(DirectiveWeWantToMock, {
+        dependency: true,
+        render: {
+          $implicit: {a: '$'},
+          variables: {a: {b: 'b'}
+        },
+      }})
+      .mock(PipeWeWantToMock, {
+        dependency: true,
+      })
+      .mock(ServiceWeWantToMock) // makes all methods an empty function
+      .mock(INJECTION_TOKEN_WE_WANT_TO_MOCK) // makes its value undefined
+
+      .mock(PipeWeWantToCustomize, (value) => 'My Custom Result')
+      .mock(PipeWeWantToRestore, (value) => 'My Restored Pipe')
+      .mock(ServiceWeWantToCustomize, {prop1: true, getName: () => 'My Customized String'})
+      .mock(INJECTION_TOKEN_WE_WANT_TO_CUSTOMIZE, 'My_Token')
+
+      // All providers will be set into the TestModule.
+      .provide({
+        provide: AnythingWeWant1,
+        useValue: new TheSameAsAnyProvider(),
+      })
+      .provide({
+        provide: AnythingWeWant2,
+        useFactory: () => new TheSameAsAnyProvider(),
+      })
+      .provide(MyCustomProvider1)
+      .provide([MyCustomProvider2, MyCustomProvider3])
+
+      // Now the pipe won't be mocked.
+      .keep(PipeWeWantToRestore)
+
+      // Extra configuration.
+      .keep(MyDirective)
+      .keep(MyPipe)
+      .mock(MyService1)
+      .keep(MyService2)
+
+      // Even it belongs to the module that is marked as kept, the component will be mocked and replaced.
+      .mock(MyComponent3)
+
+      // and now we want to build our NgModule.
+      .build()
+    ;
+
+      TestBed.configureTestingModule(ngModule);
+
+      // Extra configuration
+      TestBed.overrideTemplate(MyComponent1, 'If we need to tune testBed');
+      TestBed.overrideTemplate(MyComponent2, 'More callbacks');
+
+      return TestBed.compileComponents();
+  });
+
+  it('should render', inject([HttpBackend], (httpBackend: HttpBackend) => {
+    const fixture = MockRender(MyComponent);
+    expect(fixture).toBeDefined();
+    const content = fixture.debugElement.nativeElement.innerHTML;
+    expect(content).toContain('<div>My Content</div>');
+
+    expect(content).toContain('<div>MyComponent1: <component-1>If we need to tune testBed</component-1></div>');
+    expect(content).toContain('<div>MyComponent2: <component-2>More callbacks</component-2></div>');
+    expect(content).toContain('<div>MyComponent3: <component-3></component-3></div>');
+    expect(content).toContain('<div>ComponentWeDontWantToMock: <dont-want>ComponentWeDontWantToMock</dont-want></div>');
+    expect(content).toContain('<div>ComponentWeWantToMock: <do-want></do-want></div>');
+    expect(content).toContain('<div>ComponentStructural: -$implicit- b</div>');
+
+    expect(content).toContain('<div>MyDirective: <mydirective></mydirective></div>');
+    expect(content).toContain('<div>DirectiveWeDontWantToMock: <wedontwanttomock></wedontwanttomock></div>');
+    expect(content).toContain('<div>DirectiveWeWantToMock 1: <!----><span>render b</span></div>');
+    expect(content).toContain('<div>DirectiveWeWantToMock 2: <!---->render $</div>');
+
+    expect(content).toContain('<div>MyPipe: MyPipe:text</div>');
+    expect(content).toContain('<div>PipeWeDontWantToMock: PipeWeDontWantToMock:text</div>');
+    expect(content).toContain('<div>PipeWeWantToMock: </div>');
+    expect(content).toContain('<div>PipeWeWantToCustomize: My Custom Result</div>');
+    expect(content).toContain('<div>PipeWeWantToRestore: PipeWeWantToRestore:text</div>');
+
+    expect(content).toContain('<div>INJECTION_TOKEN_WE_DONT_WANT_TO_MOCK: INJECTION_TOKEN_WE_DONT_WANT_TO_MOCK</div>');
+    expect(content).toContain('<div>INJECTION_TOKEN_WE_WANT_TO_MOCK: </div>');
+    expect(content).toContain('<div>INJECTION_TOKEN_WE_WANT_TO_CUSTOMIZE: My_Token</div>');
+
+    expect(content).toContain('<div>anythingWeWant1: TheSameAsAnyProvider</div>');
+    expect(content).toContain('<div>anythingWeWant2: TheSameAsAnyProvider</div>');
+    expect(content).toContain('<div>myCustomProvider1: MyCustomProvider1</div>');
+    expect(content).toContain('<div>myCustomProvider2: MyCustomProvider2</div>');
+    expect(content).toContain('<div>myCustomProvider3: MyCustomProvider3</div>');
+
+    expect(content).toContain('<div>myService1: </div>');
+    expect(content).toContain('<div>myService2: MyService2</div>');
+    expect(content).toContain('<div>serviceWeDontWantToMock: ServiceWeDontWantToMock</div>');
+    expect(content).toContain('<div>serviceWeWantToCustomize: My Customized String</div>');
+    expect(content).toContain('<div>serviceWeWantToMock: </div>');
+
+    // Checking that replacement works.
+    expect(httpBackend.constructor).toBeDefined();
+    expect(httpBackend.constructor.name).toEqual('HttpClientTestingBackend');
+  }));
+});
+
+describe('MockBuilder:promise', () => {
+  beforeEach(() => MockBuilder()
+    .keep(MyComponent1)
+    .keep(MyComponent2)
+
+    // In case if you need extra customization of TestBed in promise way.
+    .beforeCompileComponents((testBed) => {
+      testBed.overrideTemplate(MyComponent1, 'If we need to tune testBed');
+    })
+    .beforeCompileComponents((testBed) => {
+      testBed.overrideTemplate(MyComponent2, 'More callbacks');
+    })
+  );
+
+  it('should render content ignoring all dependencies', () => {
+    const fixture = MockRender('<component-1></component-1><component-2></component-2>');
+    expect(fixture).toBeDefined();
+    expect(fixture.debugElement.nativeElement.innerHTML).toContain('If we need to tune testBed');
+    expect(fixture.debugElement.nativeElement.innerHTML).toContain('More callbacks');
+  });
+});

--- a/examples/MockBuilder/fixtures.components.my-component.html
+++ b/examples/MockBuilder/fixtures.components.my-component.html
@@ -1,0 +1,40 @@
+<div>My Content</div>
+
+<div>MyComponent1: <component-1></component-1></div>
+<div>MyComponent2: <component-2></component-2></div>
+<div>MyComponent3: <component-3></component-3></div>
+<div>ComponentWeDontWantToMock: <dont-want></dont-want></div>
+<div>ComponentWeWantToMock: <do-want></do-want></div>
+
+<div>MyDirective: <MyDirective></MyDirective></div>
+<div>DirectiveWeDontWantToMock: <WeDontWantToMock></WeDontWantToMock></div>
+<div>DirectiveWeWantToMock 1: <span *WeWantToMock="let z = a;">render {{ z.b }}</span></div>
+<div>DirectiveWeWantToMock 2: <ng-template WeWantToMock let-z>render {{ z.a }}</ng-template></div>
+
+<div>MyPipe: {{ 'text' | MyPipe }}</div>
+<div>PipeWeDontWantToMock: {{ 'text' | PipeWeDontWantToMock }}</div>
+<div>PipeWeWantToMock: {{ 'text' | PipeWeWantToMock }}</div>
+<div>PipeWeWantToCustomize: {{ 'text' | PipeWeWantToCustomize }}</div>
+<div>PipeWeWantToRestore: {{ 'text' | PipeWeWantToRestore }}</div>
+
+<div>INJECTION_TOKEN_WE_DONT_WANT_TO_MOCK: {{ t1v }}</div>
+<div>INJECTION_TOKEN_WE_WANT_TO_MOCK: {{ t2v }}</div>
+<div>INJECTION_TOKEN_WE_WANT_TO_CUSTOMIZE: {{ t3v }}</div>
+
+<div>anythingWeWant1: {{ anythingWeWant1?.getName() }}</div>
+<div>anythingWeWant2: {{ anythingWeWant2?.getName() }}</div>
+<div>myCustomProvider1: {{ myCustomProvider1?.getName() }}</div>
+<div>myCustomProvider2: {{ myCustomProvider2?.getName() }}</div>
+<div>myCustomProvider3: {{ myCustomProvider3?.getName() }}</div>
+
+<div>myService1: {{ myService1?.getName() }}</div>
+<div>myService2: {{ myService2?.getName() }}</div>
+<div>serviceWeDontWantToMock: {{ serviceWeDontWantToMock?.getName() }}</div>
+<div>serviceWeWantToCustomize: {{ serviceWeWantToCustomize?.getName() }}</div>
+<div>serviceWeWantToMock: {{ serviceWeWantToMock?.getName() }}</div>
+
+<component-structural>
+    <ng-template let-value let-b="a" #block>
+        <div>ComponentStructural: {{value}} {{ b.z }}</div>
+    </ng-template>
+</component-structural>

--- a/examples/MockBuilder/fixtures.components.ts
+++ b/examples/MockBuilder/fixtures.components.ts
@@ -1,0 +1,114 @@
+// tslint:disable:max-classes-per-file
+
+import { Component, ContentChild, Inject, Input, Optional, TemplateRef } from '@angular/core';
+import { staticFalse } from '../../tests';
+import {
+  AnythingWeWant1,
+  AnythingWeWant2,
+  MyCustomProvider1,
+  MyCustomProvider2,
+  MyCustomProvider3,
+  MyService1,
+  MyService2,
+  ServiceWeDontWantToMock,
+  ServiceWeWantToCustomize,
+  ServiceWeWantToMock,
+} from './fixtures.services';
+import {
+  INJECTION_TOKEN_WE_DONT_WANT_TO_MOCK,
+  INJECTION_TOKEN_WE_WANT_TO_CUSTOMIZE,
+  INJECTION_TOKEN_WE_WANT_TO_MOCK,
+} from './fixtures.tokens';
+
+@Component({
+  selector: 'component-structural',
+  template: `
+      <div *ngIf="items && items.length">
+          <ng-template ngFor [ngForOf]="items" [ngForTemplate]="injectedBlock"></ng-template>
+      </div>
+  `,
+})
+export class ComponentContentChild<T> {
+  @ContentChild('block', {...staticFalse}) injectedBlock: TemplateRef<any>;
+  @Input() items?: T[];
+}
+
+@Component({
+  selector: 'my-component',
+  template: require('./fixtures.components.my-component.html'), // tslint:disable-line:no-require-imports
+})
+export class MyComponent {
+  public readonly anythingWeWant1: AnythingWeWant1;
+  public readonly anythingWeWant2: AnythingWeWant2;
+  public readonly myCustomProvider1: MyCustomProvider1;
+  public readonly myCustomProvider2: MyCustomProvider2;
+  public readonly myCustomProvider3: MyCustomProvider3;
+  public readonly myService1: MyService1;
+  public readonly myService2: MyService2;
+  public readonly serviceWeDontWantToMock: ServiceWeDontWantToMock;
+  public readonly serviceWeWantToCustomize: ServiceWeWantToCustomize;
+  public readonly serviceWeWantToMock: ServiceWeWantToMock;
+  public readonly t1v: string;
+  public readonly t2v: string;
+  public readonly t3v: string;
+
+  constructor(
+    @Optional() @Inject(INJECTION_TOKEN_WE_DONT_WANT_TO_MOCK) t1: string,
+    @Optional() @Inject(INJECTION_TOKEN_WE_WANT_TO_MOCK) t2: string,
+    @Optional() @Inject(INJECTION_TOKEN_WE_WANT_TO_CUSTOMIZE) t3: string,
+    @Optional() anythingWeWant1: AnythingWeWant1,
+    @Optional() anythingWeWant2: AnythingWeWant2,
+    @Optional() myCustomProvider1: MyCustomProvider1,
+    @Optional() myCustomProvider2: MyCustomProvider2,
+    @Optional() myCustomProvider3: MyCustomProvider3,
+    @Optional() myService1: MyService1,
+    @Optional() myService2: MyService2,
+    @Optional() serviceWeDontWantToMock: ServiceWeDontWantToMock,
+    @Optional() serviceWeWantToMock: ServiceWeWantToMock,
+    @Optional() serviceWeWantToCustomize: ServiceWeWantToCustomize,
+  ) {
+    this.t1v = t1;
+    this.t2v = t2;
+    this.t3v = t3;
+    this.anythingWeWant1 = anythingWeWant1;
+    this.anythingWeWant2 = anythingWeWant2;
+    this.myCustomProvider1 = myCustomProvider1;
+    this.myCustomProvider2 = myCustomProvider2;
+    this.myCustomProvider3 = myCustomProvider3;
+    this.myService1 = myService1;
+    this.myService2 = myService2;
+    this.serviceWeDontWantToMock = serviceWeDontWantToMock;
+    this.serviceWeWantToCustomize = serviceWeWantToCustomize;
+    this.serviceWeWantToMock = serviceWeWantToMock;
+  }
+}
+
+@Component({
+  selector: 'component-1',
+  template: 'MyComponent1',
+})
+export class MyComponent1 {}
+
+@Component({
+  selector: 'component-2',
+  template: 'MyComponent2',
+})
+export class MyComponent2 {}
+
+@Component({
+  selector: 'component-3',
+  template: 'MyComponent3',
+})
+export class MyComponent3 {}
+
+@Component({
+  selector: 'dont-want',
+  template: 'ComponentWeDontWantToMock',
+})
+export class ComponentWeDontWantToMock {}
+
+@Component({
+  selector: 'do-want',
+  template: 'ComponentWeWantToMock',
+})
+export class ComponentWeWantToMock {}

--- a/examples/MockBuilder/fixtures.directives.ts
+++ b/examples/MockBuilder/fixtures.directives.ts
@@ -1,0 +1,18 @@
+// tslint:disable:max-classes-per-file
+
+import { Directive } from '@angular/core';
+
+@Directive({
+  selector: 'MyDirective',
+})
+export class MyDirective {}
+
+@Directive({
+  selector: 'WeDontWantToMock',
+})
+export class DirectiveWeDontWantToMock {}
+
+@Directive({
+  selector: '[WeWantToMock]',
+})
+export class DirectiveWeWantToMock {}

--- a/examples/MockBuilder/fixtures.modules.ts
+++ b/examples/MockBuilder/fixtures.modules.ts
@@ -1,0 +1,121 @@
+// tslint:disable:max-classes-per-file
+
+import { HttpClientModule } from '@angular/common/http';
+import { NgModule } from '@angular/core';
+
+import {
+  ComponentContentChild,
+  ComponentWeDontWantToMock,
+  ComponentWeWantToMock,
+  MyComponent,
+  MyComponent1,
+  MyComponent2, MyComponent3,
+} from './fixtures.components';
+import {
+  DirectiveWeDontWantToMock,
+  DirectiveWeWantToMock,
+  MyDirective,
+} from './fixtures.directives';
+import {
+  MyPipe,
+  PipeWeDontWantToMock,
+  PipeWeWantToCustomize,
+  PipeWeWantToMock,
+  PipeWeWantToRestore,
+} from './fixtures.pipes';
+import {
+  MyService1,
+  MyService2,
+  ServiceWeDontWantToMock,
+  ServiceWeWantToCustomize,
+  ServiceWeWantToMock,
+} from './fixtures.services';
+import {
+  INJECTION_TOKEN_WE_DONT_WANT_TO_MOCK,
+  INJECTION_TOKEN_WE_WANT_TO_CUSTOMIZE,
+  INJECTION_TOKEN_WE_WANT_TO_MOCK,
+} from './fixtures.tokens';
+import { CommonModule } from '@angular/common';
+
+@NgModule({
+  declarations: [
+    ComponentWeDontWantToMock,
+    ComponentWeWantToMock,
+    DirectiveWeDontWantToMock,
+    DirectiveWeWantToMock,
+    PipeWeDontWantToMock,
+    PipeWeWantToMock,
+    PipeWeWantToCustomize,
+    PipeWeWantToRestore,
+  ],
+  exports: [
+    ComponentWeDontWantToMock,
+    ComponentWeWantToMock,
+    DirectiveWeDontWantToMock,
+    DirectiveWeWantToMock,
+    PipeWeDontWantToMock,
+    PipeWeWantToMock,
+    PipeWeWantToCustomize,
+    PipeWeWantToRestore,
+  ],
+  providers: [
+    ServiceWeDontWantToMock,
+    ServiceWeWantToMock,
+    {
+      provide: INJECTION_TOKEN_WE_DONT_WANT_TO_MOCK,
+      useValue: 'INJECTION_TOKEN_WE_DONT_WANT_TO_MOCK',
+    },
+    {
+      provide: INJECTION_TOKEN_WE_WANT_TO_MOCK,
+      useValue: 'INJECTION_TOKEN_WE_WANT_TO_MOCK',
+    },
+    {
+      provide: INJECTION_TOKEN_WE_WANT_TO_CUSTOMIZE,
+      useValue: 'INJECTION_TOKEN_WE_WANT_TO_CUSTOMIZE',
+    },
+  ],
+})
+export class ModuleWeWantToMockBesidesMyModule {}
+
+@NgModule({
+  declarations: [
+    MyComponent1,
+    MyComponent2,
+    MyComponent3,
+    ComponentContentChild,
+  ],
+  exports: [
+    MyComponent1,
+    MyComponent2,
+    MyComponent3,
+    ComponentContentChild,
+  ],
+  imports: [
+    CommonModule,
+  ],
+})
+export class ModuleWeDontWantToMock {}
+
+@NgModule({
+  declarations: [
+    MyComponent,
+    MyDirective,
+    MyPipe,
+  ],
+  exports: [
+    MyComponent,
+    MyDirective,
+    MyPipe,
+  ],
+  imports: [
+    HttpClientModule,
+    ModuleWeWantToMockBesidesMyModule,
+    ModuleWeDontWantToMock,
+  ],
+  providers: [
+    MyService1,
+    MyService2,
+    ServiceWeWantToCustomize,
+  ],
+})
+export class MyModule {}

--- a/examples/MockBuilder/fixtures.pipes.ts
+++ b/examples/MockBuilder/fixtures.pipes.ts
@@ -1,0 +1,58 @@
+// tslint:disable:max-classes-per-file
+
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'MyPipe',
+})
+export class MyPipe implements PipeTransform {
+  protected prefix = 'MyPipe:';
+
+  public transform(value: any, ...args: any[]): any {
+    return this.prefix + value;
+  }
+}
+
+@Pipe({
+  name: 'PipeWeDontWantToMock',
+})
+export class PipeWeDontWantToMock implements PipeTransform {
+  protected prefix = 'PipeWeDontWantToMock:';
+
+  public transform(value: any, ...args: any[]): any {
+    return this.prefix + value;
+  }
+}
+
+@Pipe({
+  name: 'PipeWeWantToMock',
+})
+export class PipeWeWantToMock implements PipeTransform {
+  protected prefix = 'PipeWeWantToMock:';
+
+  public transform(value: any, ...args: any[]): any {
+    return this.prefix + value;
+  }
+}
+
+@Pipe({
+  name: 'PipeWeWantToCustomize',
+})
+export class PipeWeWantToCustomize implements PipeTransform {
+  protected prefix = 'PipeWeWantToCustomize:';
+
+  public transform(value: any, ...args: any[]): any {
+    return this.prefix + value;
+  }
+}
+
+@Pipe({
+  name: 'PipeWeWantToRestore',
+})
+export class PipeWeWantToRestore implements PipeTransform {
+  protected prefix = 'PipeWeWantToRestore:';
+
+  public transform(value: any, ...args: any[]): any {
+    return this.prefix + value;
+  }
+}

--- a/examples/MockBuilder/fixtures.services.ts
+++ b/examples/MockBuilder/fixtures.services.ts
@@ -1,0 +1,102 @@
+// tslint:disable:max-classes-per-file
+
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class MyService1 {
+  protected value = 'MyService1';
+
+  public getName() {
+    return this.value;
+  }
+}
+
+@Injectable()
+export class MyService2 {
+  protected value = 'MyService2';
+
+  public getName() {
+    return this.value;
+  }
+}
+
+@Injectable()
+export class ServiceWeDontWantToMock {
+  protected value = 'ServiceWeDontWantToMock';
+
+  public getName() {
+    return this.value;
+  }
+}
+
+@Injectable()
+export class ServiceWeWantToMock {
+  protected value = 'ServiceWeWantToMock';
+
+  public getName() {
+    return this.value;
+  }
+}
+
+@Injectable()
+export class ServiceWeWantToCustomize {
+  protected value = 'ServiceWeWantToCustomize';
+
+  public getName() {
+    return this.value;
+  }
+}
+
+@Injectable()
+export class AnythingWeWant1 {
+  protected value = 'AnythingWeWant1';
+
+  public getName() {
+    return this.value;
+  }
+}
+
+@Injectable()
+export class TheSameAsAnyProvider {
+  protected value = 'TheSameAsAnyProvider';
+
+  public getName() {
+    return this.value;
+  }
+}
+
+@Injectable()
+export class AnythingWeWant2 {
+  protected value = 'AnythingWeWant2';
+
+  public getName() {
+    return this.value;
+  }
+}
+
+@Injectable()
+export class MyCustomProvider1 {
+  protected value = 'MyCustomProvider1';
+
+  public getName() {
+    return this.value;
+  }
+}
+
+@Injectable()
+export class MyCustomProvider2 {
+  protected value = 'MyCustomProvider2';
+
+  public getName() {
+    return this.value;
+  }
+}
+
+@Injectable()
+export class MyCustomProvider3 {
+  protected value = 'MyCustomProvider3';
+
+  public getName() {
+    return this.value;
+  }
+}

--- a/examples/MockBuilder/fixtures.tokens.ts
+++ b/examples/MockBuilder/fixtures.tokens.ts
@@ -1,0 +1,9 @@
+// tslint:disable:max-classes-per-file
+
+import { InjectionToken } from '@angular/core';
+
+export const INJECTION_TOKEN_WE_DONT_WANT_TO_MOCK = new InjectionToken('INJECTION_TOKEN_WE_DONT_WANT_TO_MOCK');
+
+export const INJECTION_TOKEN_WE_WANT_TO_MOCK = new InjectionToken('INJECTION_TOKEN_WE_WANT_TO_MOCK');
+
+export const INJECTION_TOKEN_WE_WANT_TO_CUSTOMIZE = new InjectionToken('INJECTION_TOKEN_WE_WANT_TO_CUSTOMIZE');

--- a/examples/NG_MOCKS/NG_MOCKS.spec.ts
+++ b/examples/NG_MOCKS/NG_MOCKS.spec.ts
@@ -1,0 +1,132 @@
+import { HttpClientModule } from '@angular/common/http';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { inject, TestBed } from '@angular/core/testing';
+import {
+  isMockedNgDefOf,
+  MockBuilder,
+  NG_MOCKS,
+} from 'ng-mocks';
+
+import {
+  ComponentWeDontWantToMock,
+  ComponentWeWantToMock,
+  MyComponent,
+  MyComponent1,
+  MyComponent2,
+  MyComponent3,
+} from './fixtures.components';
+import { DirectiveWeDontWantToMock, DirectiveWeWantToMock } from './fixtures.directives';
+import { ModuleWeDontWantToMock, ModuleWeWantToMockBesidesMyModule, MyModule } from './fixtures.modules';
+import { PipeWeDontWantToMock, PipeWeWantToMock, PipeWeWantToRestore } from './fixtures.pipes';
+import { ServiceWeDontWantToMock, ServiceWeWantToCustomize, ServiceWeWantToMock } from './fixtures.services';
+import {
+  INJECTION_TOKEN_WE_DONT_WANT_TO_MOCK,
+  INJECTION_TOKEN_WE_WANT_TO_CUSTOMIZE,
+  INJECTION_TOKEN_WE_WANT_TO_MOCK,
+} from './fixtures.tokens';
+
+describe('NG_MOCKS:deep', () => {
+  beforeEach(async () => {
+    const ngModule = MockBuilder(MyComponent, MyModule)
+
+      .keep(ModuleWeDontWantToMock)
+      .keep(ComponentWeDontWantToMock)
+      .keep(DirectiveWeDontWantToMock)
+      .keep(PipeWeDontWantToMock)
+      .keep(ServiceWeDontWantToMock)
+      .keep(INJECTION_TOKEN_WE_DONT_WANT_TO_MOCK)
+
+      .replace(HttpClientModule, HttpClientTestingModule)
+
+      .mock(ModuleWeWantToMockBesidesMyModule)
+      .mock(ComponentWeWantToMock)
+      .mock(DirectiveWeWantToMock)
+      .mock(PipeWeWantToMock)
+      .mock(ServiceWeWantToMock) // makes all methods an empty function
+      .mock(INJECTION_TOKEN_WE_WANT_TO_MOCK) // makes its value undefined
+
+      .mock(ServiceWeWantToCustomize, {prop1: true, getName: () => 'My Customized String'})
+      .mock(INJECTION_TOKEN_WE_WANT_TO_CUSTOMIZE, 'My_Token')
+
+      // Now the pipe won't be mocked.
+      .keep(PipeWeWantToRestore)
+
+      // Even it belongs to the module to keep it still will be mocked and replaced.
+      .mock(MyComponent3)
+
+      // and now we want to build our NgModule.
+      .build()
+    ;
+
+    TestBed.configureTestingModule(ngModule);
+
+    // Extra configuration
+    TestBed.overrideTemplate(MyComponent1, 'If we need to tune testBed');
+    TestBed.overrideTemplate(MyComponent2, 'More callbacks');
+
+    return TestBed.compileComponents();
+  });
+
+  it('should contain mocks', inject([NG_MOCKS], (mocks: Map<any, any>) => {
+    // main part
+    const myComponent = mocks.get(MyComponent);
+    expect(myComponent).toBe(MyComponent);
+    const myModule = mocks.get(MyModule);
+    expect(isMockedNgDefOf(myModule, MyModule, 'm')).toBeTruthy('myModule');
+
+    // keep
+    const componentWeDontWantToMock = mocks.get(ComponentWeDontWantToMock);
+    expect(componentWeDontWantToMock).toBe(ComponentWeDontWantToMock);
+    const directiveWeDontWantToMock = mocks.get(DirectiveWeDontWantToMock);
+    expect(directiveWeDontWantToMock).toBe(DirectiveWeDontWantToMock);
+    const pipeWeDontWantToMock = mocks.get(PipeWeDontWantToMock);
+    expect(pipeWeDontWantToMock).toBe(PipeWeDontWantToMock);
+    const serviceWeDontWantToMock = mocks.get(ServiceWeDontWantToMock);
+    expect(serviceWeDontWantToMock).toBe(ServiceWeDontWantToMock);
+    const injectionTokenWeDontWantToMock = mocks.get(INJECTION_TOKEN_WE_DONT_WANT_TO_MOCK);
+    expect(injectionTokenWeDontWantToMock).toBe(INJECTION_TOKEN_WE_DONT_WANT_TO_MOCK);
+
+    // replace
+    const httpClientModule = mocks.get(HttpClientModule);
+    expect(httpClientModule).toBe(HttpClientTestingModule);
+
+    // mock
+    const moduleWeWantToMockBesidesMyModule = mocks.get(ModuleWeWantToMockBesidesMyModule);
+    expect(isMockedNgDefOf(moduleWeWantToMockBesidesMyModule, ModuleWeWantToMockBesidesMyModule, 'm'))
+      .toBeTruthy('moduleWeWantToMockBesidesMyModule');
+    const componentWeWantToMock = mocks.get(ComponentWeWantToMock);
+    expect(isMockedNgDefOf(componentWeWantToMock, ComponentWeWantToMock, 'c')).toBeTruthy('componentWeWantToMock');
+    const directiveWeWantToMock = mocks.get(DirectiveWeWantToMock);
+    expect(isMockedNgDefOf(directiveWeWantToMock, DirectiveWeWantToMock, 'd')).toBeTruthy('directiveWeWantToMock');
+    const pipeWeWantToMock = mocks.get(PipeWeWantToMock);
+    expect(isMockedNgDefOf(pipeWeWantToMock, PipeWeWantToMock, 'p')).toBeTruthy('pipeWeWantToMock');
+    const serviceWeWantToMock = mocks.get(ServiceWeWantToMock);
+    expect(serviceWeWantToMock).toBeDefined('serviceWeWantToMock');
+    expect(serviceWeWantToMock.useValue).toBeDefined('serviceWeWantToMock.useValue');
+    expect(serviceWeWantToMock.useValue.getName).toBeDefined('serviceWeWantToMock.getName');
+    expect(serviceWeWantToMock.useValue.getName()).toBeUndefined('serviceWeWantToMock.getName()');
+    const injectionTokenWeWantToMock = mocks.get(INJECTION_TOKEN_WE_WANT_TO_MOCK);
+    expect(injectionTokenWeWantToMock).toBeDefined('injectionTokenWeWantToMock');
+    expect(injectionTokenWeWantToMock.useValue).toBeUndefined('injectionTokenWeWantToMock.useValue');
+
+    // customize
+    const serviceWeWantToCustomize = mocks.get(ServiceWeWantToCustomize);
+    expect(serviceWeWantToCustomize).toBeDefined('serviceWeWantToCustomize');
+    expect(serviceWeWantToCustomize.useValue).toBeDefined('serviceWeWantToCustomize.useValue');
+    expect(serviceWeWantToCustomize.useValue.getName).toBeDefined('serviceWeWantToCustomize.getName');
+    expect(serviceWeWantToCustomize.useValue.getName())
+      .toEqual('My Customized String', 'serviceWeWantToCustomize.getName()');
+    expect(serviceWeWantToCustomize.useValue.prop1).toEqual(true, 'serviceWeWantToCustomize.prop1');
+    const injectionTokenWeWantToCustomize = mocks.get(INJECTION_TOKEN_WE_WANT_TO_CUSTOMIZE);
+    expect(injectionTokenWeWantToCustomize).toBeDefined('injectionTokenWeWantToCustomize');
+    expect(injectionTokenWeWantToCustomize.useValue).toEqual('My_Token', 'injectionTokenWeWantToCustomize.useValue');
+
+    // restore
+    const pipeWeWantToRestore = mocks.get(PipeWeWantToRestore);
+    expect(pipeWeWantToRestore).toBe(PipeWeWantToRestore);
+
+    // mock nested
+    const myComponent3 = mocks.get(MyComponent3);
+    expect(isMockedNgDefOf(myComponent3, MyComponent3, 'c')).toBeTruthy('myComponent3');
+  }));
+});

--- a/examples/NG_MOCKS/fixtures.components.ts
+++ b/examples/NG_MOCKS/fixtures.components.ts
@@ -1,0 +1,110 @@
+// tslint:disable:max-classes-per-file
+
+import { Component, ContentChild, Inject, Input, Optional, TemplateRef } from '@angular/core';
+import { staticFalse } from '../../tests';
+import {
+  AnythingWeWant1,
+  AnythingWeWant2,
+  MyCustomProvider1,
+  MyCustomProvider2,
+  MyCustomProvider3,
+  MyService1,
+  MyService2,
+  ServiceWeDontWantToMock,
+  ServiceWeWantToCustomize,
+  ServiceWeWantToMock,
+} from './fixtures.services';
+import {
+  INJECTION_TOKEN_WE_DONT_WANT_TO_MOCK,
+  INJECTION_TOKEN_WE_WANT_TO_CUSTOMIZE,
+  INJECTION_TOKEN_WE_WANT_TO_MOCK,
+} from './fixtures.tokens';
+
+@Component({
+  selector: 'component-structural',
+  template: '',
+})
+export class ComponentContentChild<T> {
+  @ContentChild('block', {...staticFalse}) injectedBlock: TemplateRef<any>;
+  @Input() items?: T[];
+}
+
+@Component({
+  selector: 'my-component',
+  template: '',
+})
+export class MyComponent {
+  public readonly anythingWeWant1: AnythingWeWant1;
+  public readonly anythingWeWant2: AnythingWeWant2;
+  public readonly myCustomProvider1: MyCustomProvider1;
+  public readonly myCustomProvider2: MyCustomProvider2;
+  public readonly myCustomProvider3: MyCustomProvider3;
+  public readonly myService1: MyService1;
+  public readonly myService2: MyService2;
+  public readonly serviceWeDontWantToMock: ServiceWeDontWantToMock;
+  public readonly serviceWeWantToCustomize: ServiceWeWantToCustomize;
+  public readonly serviceWeWantToMock: ServiceWeWantToMock;
+  public readonly t1v: string;
+  public readonly t2v: string;
+  public readonly t3v: string;
+
+  constructor(
+    @Optional() @Inject(INJECTION_TOKEN_WE_DONT_WANT_TO_MOCK) t1: string,
+    @Optional() @Inject(INJECTION_TOKEN_WE_WANT_TO_MOCK) t2: string,
+    @Optional() @Inject(INJECTION_TOKEN_WE_WANT_TO_CUSTOMIZE) t3: string,
+    @Optional() anythingWeWant1: AnythingWeWant1,
+    @Optional() anythingWeWant2: AnythingWeWant2,
+    @Optional() myCustomProvider1: MyCustomProvider1,
+    @Optional() myCustomProvider2: MyCustomProvider2,
+    @Optional() myCustomProvider3: MyCustomProvider3,
+    @Optional() myService1: MyService1,
+    @Optional() myService2: MyService2,
+    @Optional() serviceWeDontWantToMock: ServiceWeDontWantToMock,
+    @Optional() serviceWeWantToMock: ServiceWeWantToMock,
+    @Optional() serviceWeWantToCustomize: ServiceWeWantToCustomize,
+  ) {
+    this.t1v = t1;
+    this.t2v = t2;
+    this.t3v = t3;
+    this.anythingWeWant1 = anythingWeWant1;
+    this.anythingWeWant2 = anythingWeWant2;
+    this.myCustomProvider1 = myCustomProvider1;
+    this.myCustomProvider2 = myCustomProvider2;
+    this.myCustomProvider3 = myCustomProvider3;
+    this.myService1 = myService1;
+    this.myService2 = myService2;
+    this.serviceWeDontWantToMock = serviceWeDontWantToMock;
+    this.serviceWeWantToCustomize = serviceWeWantToCustomize;
+    this.serviceWeWantToMock = serviceWeWantToMock;
+  }
+}
+
+@Component({
+  selector: 'component-1',
+  template: 'MyComponent1',
+})
+export class MyComponent1 {}
+
+@Component({
+  selector: 'component-2',
+  template: 'MyComponent2',
+})
+export class MyComponent2 {}
+
+@Component({
+  selector: 'component-3',
+  template: 'MyComponent3',
+})
+export class MyComponent3 {}
+
+@Component({
+  selector: 'dont-want',
+  template: 'ComponentWeDontWantToMock',
+})
+export class ComponentWeDontWantToMock {}
+
+@Component({
+  selector: 'do-want',
+  template: 'ComponentWeWantToMock',
+})
+export class ComponentWeWantToMock {}

--- a/examples/NG_MOCKS/fixtures.directives.ts
+++ b/examples/NG_MOCKS/fixtures.directives.ts
@@ -1,0 +1,18 @@
+// tslint:disable:max-classes-per-file
+
+import { Directive } from '@angular/core';
+
+@Directive({
+  selector: 'MyDirective',
+})
+export class MyDirective {}
+
+@Directive({
+  selector: 'WeDontWantToMock',
+})
+export class DirectiveWeDontWantToMock {}
+
+@Directive({
+  selector: '[WeWantToMock]',
+})
+export class DirectiveWeWantToMock {}

--- a/examples/NG_MOCKS/fixtures.modules.ts
+++ b/examples/NG_MOCKS/fixtures.modules.ts
@@ -1,0 +1,121 @@
+// tslint:disable:max-classes-per-file
+
+import { HttpClientModule } from '@angular/common/http';
+import { NgModule } from '@angular/core';
+
+import {
+  ComponentContentChild,
+  ComponentWeDontWantToMock,
+  ComponentWeWantToMock,
+  MyComponent,
+  MyComponent1,
+  MyComponent2, MyComponent3,
+} from './fixtures.components';
+import {
+  DirectiveWeDontWantToMock,
+  DirectiveWeWantToMock,
+  MyDirective,
+} from './fixtures.directives';
+import {
+  MyPipe,
+  PipeWeDontWantToMock,
+  PipeWeWantToCustomize,
+  PipeWeWantToMock,
+  PipeWeWantToRestore,
+} from './fixtures.pipes';
+import {
+  MyService1,
+  MyService2,
+  ServiceWeDontWantToMock,
+  ServiceWeWantToCustomize,
+  ServiceWeWantToMock,
+} from './fixtures.services';
+import {
+  INJECTION_TOKEN_WE_DONT_WANT_TO_MOCK,
+  INJECTION_TOKEN_WE_WANT_TO_CUSTOMIZE,
+  INJECTION_TOKEN_WE_WANT_TO_MOCK,
+} from './fixtures.tokens';
+import { CommonModule } from '@angular/common';
+
+@NgModule({
+  declarations: [
+    ComponentWeDontWantToMock,
+    ComponentWeWantToMock,
+    DirectiveWeDontWantToMock,
+    DirectiveWeWantToMock,
+    PipeWeDontWantToMock,
+    PipeWeWantToMock,
+    PipeWeWantToCustomize,
+    PipeWeWantToRestore,
+  ],
+  exports: [
+    ComponentWeDontWantToMock,
+    ComponentWeWantToMock,
+    DirectiveWeDontWantToMock,
+    DirectiveWeWantToMock,
+    PipeWeDontWantToMock,
+    PipeWeWantToMock,
+    PipeWeWantToCustomize,
+    PipeWeWantToRestore,
+  ],
+  providers: [
+    ServiceWeDontWantToMock,
+    ServiceWeWantToMock,
+    {
+      provide: INJECTION_TOKEN_WE_DONT_WANT_TO_MOCK,
+      useValue: 'INJECTION_TOKEN_WE_DONT_WANT_TO_MOCK',
+    },
+    {
+      provide: INJECTION_TOKEN_WE_WANT_TO_MOCK,
+      useValue: 'INJECTION_TOKEN_WE_WANT_TO_MOCK',
+    },
+    {
+      provide: INJECTION_TOKEN_WE_WANT_TO_CUSTOMIZE,
+      useValue: 'INJECTION_TOKEN_WE_WANT_TO_CUSTOMIZE',
+    },
+  ],
+})
+export class ModuleWeWantToMockBesidesMyModule {}
+
+@NgModule({
+  declarations: [
+    MyComponent1,
+    MyComponent2,
+    MyComponent3,
+    ComponentContentChild,
+  ],
+  exports: [
+    MyComponent1,
+    MyComponent2,
+    MyComponent3,
+    ComponentContentChild,
+  ],
+  imports: [
+    CommonModule,
+  ],
+})
+export class ModuleWeDontWantToMock {}
+
+@NgModule({
+  declarations: [
+    MyComponent,
+    MyDirective,
+    MyPipe,
+  ],
+  exports: [
+    MyComponent,
+    MyDirective,
+    MyPipe,
+  ],
+  imports: [
+    HttpClientModule,
+    ModuleWeWantToMockBesidesMyModule,
+    ModuleWeDontWantToMock,
+  ],
+  providers: [
+    MyService1,
+    MyService2,
+    ServiceWeWantToCustomize,
+  ],
+})
+export class MyModule {}

--- a/examples/NG_MOCKS/fixtures.pipes.ts
+++ b/examples/NG_MOCKS/fixtures.pipes.ts
@@ -1,0 +1,58 @@
+// tslint:disable:max-classes-per-file
+
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'MyPipe',
+})
+export class MyPipe implements PipeTransform {
+  protected prefix = 'MyPipe:';
+
+  public transform(value: any, ...args: any[]): any {
+    return this.prefix + value;
+  }
+}
+
+@Pipe({
+  name: 'PipeWeDontWantToMock',
+})
+export class PipeWeDontWantToMock implements PipeTransform {
+  protected prefix = 'PipeWeDontWantToMock:';
+
+  public transform(value: any, ...args: any[]): any {
+    return this.prefix + value;
+  }
+}
+
+@Pipe({
+  name: 'PipeWeWantToMock',
+})
+export class PipeWeWantToMock implements PipeTransform {
+  protected prefix = 'PipeWeWantToMock:';
+
+  public transform(value: any, ...args: any[]): any {
+    return this.prefix + value;
+  }
+}
+
+@Pipe({
+  name: 'PipeWeWantToCustomize',
+})
+export class PipeWeWantToCustomize implements PipeTransform {
+  protected prefix = 'PipeWeWantToCustomize:';
+
+  public transform(value: any, ...args: any[]): any {
+    return this.prefix + value;
+  }
+}
+
+@Pipe({
+  name: 'PipeWeWantToRestore',
+})
+export class PipeWeWantToRestore implements PipeTransform {
+  protected prefix = 'PipeWeWantToRestore:';
+
+  public transform(value: any, ...args: any[]): any {
+    return this.prefix + value;
+  }
+}

--- a/examples/NG_MOCKS/fixtures.services.ts
+++ b/examples/NG_MOCKS/fixtures.services.ts
@@ -1,0 +1,102 @@
+// tslint:disable:max-classes-per-file
+
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class MyService1 {
+  protected value = 'MyService1';
+
+  public getName() {
+    return this.value;
+  }
+}
+
+@Injectable()
+export class MyService2 {
+  protected value = 'MyService2';
+
+  public getName() {
+    return this.value;
+  }
+}
+
+@Injectable()
+export class ServiceWeDontWantToMock {
+  protected value = 'ServiceWeDontWantToMock';
+
+  public getName() {
+    return this.value;
+  }
+}
+
+@Injectable()
+export class ServiceWeWantToMock {
+  protected value = 'ServiceWeWantToMock';
+
+  public getName() {
+    return this.value;
+  }
+}
+
+@Injectable()
+export class ServiceWeWantToCustomize {
+  protected value = 'ServiceWeWantToCustomize';
+
+  public getName() {
+    return this.value;
+  }
+}
+
+@Injectable()
+export class AnythingWeWant1 {
+  protected value = 'AnythingWeWant1';
+
+  public getName() {
+    return this.value;
+  }
+}
+
+@Injectable()
+export class TheSameAsAnyProvider {
+  protected value = 'TheSameAsAnyProvider';
+
+  public getName() {
+    return this.value;
+  }
+}
+
+@Injectable()
+export class AnythingWeWant2 {
+  protected value = 'AnythingWeWant2';
+
+  public getName() {
+    return this.value;
+  }
+}
+
+@Injectable()
+export class MyCustomProvider1 {
+  protected value = 'MyCustomProvider1';
+
+  public getName() {
+    return this.value;
+  }
+}
+
+@Injectable()
+export class MyCustomProvider2 {
+  protected value = 'MyCustomProvider2';
+
+  public getName() {
+    return this.value;
+  }
+}
+
+@Injectable()
+export class MyCustomProvider3 {
+  protected value = 'MyCustomProvider3';
+
+  public getName() {
+    return this.value;
+  }
+}

--- a/examples/NG_MOCKS/fixtures.tokens.ts
+++ b/examples/NG_MOCKS/fixtures.tokens.ts
@@ -1,0 +1,9 @@
+// tslint:disable:max-classes-per-file
+
+import { InjectionToken } from '@angular/core';
+
+export const INJECTION_TOKEN_WE_DONT_WANT_TO_MOCK = new InjectionToken('INJECTION_TOKEN_WE_DONT_WANT_TO_MOCK');
+
+export const INJECTION_TOKEN_WE_WANT_TO_MOCK = new InjectionToken('INJECTION_TOKEN_WE_WANT_TO_MOCK');
+
+export const INJECTION_TOKEN_WE_WANT_TO_CUSTOMIZE = new InjectionToken('INJECTION_TOKEN_WE_WANT_TO_CUSTOMIZE');

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,5 @@
 export * from './lib/common';
+export * from './lib/mock-builder';
 export * from './lib/mock-component';
 export * from './lib/mock-declaration';
 export * from './lib/mock-directive';

--- a/lib/common/Mock.spec.ts
+++ b/lib/common/Mock.spec.ts
@@ -11,17 +11,60 @@ class ParentClass {
   }
 }
 
-@NgModule({})
+@NgModule({
+  providers: [
+    {
+      provide: 'MOCK',
+      useValue: 'HELLO',
+    },
+  ]
+})
+class ChildModuleClass extends ParentClass implements PipeTransform {
+  protected childValue = true;
+
+  public childMethod(): boolean {
+    return this.childValue;
+  }
+
+  transform(): string {
+    return typeof this.childValue;
+  }
+}
+
 @Component({
   template: '',
 })
+class ChildComponentClass extends ParentClass implements PipeTransform {
+  protected childValue = true;
+
+  public childMethod(): boolean {
+    return this.childValue;
+  }
+
+  transform(): string {
+    return typeof this.childValue;
+  }
+}
+
 @Directive({
   selector: 'mock',
 })
+class ChildDirectiveClass extends ParentClass implements PipeTransform {
+  protected childValue = true;
+
+  public childMethod(): boolean {
+    return this.childValue;
+  }
+
+  transform(): string {
+    return typeof this.childValue;
+  }
+}
+
 @Pipe({
   name: 'mock',
 })
-class ChildClass extends ParentClass implements PipeTransform {
+class ChildPipeClass extends ParentClass implements PipeTransform {
   protected childValue = true;
 
   public childMethod(): boolean {
@@ -35,14 +78,14 @@ class ChildClass extends ParentClass implements PipeTransform {
 
 describe('Mock', () => {
   it('should affect as MockModule', () => {
-    const instance = new (MockModule(ChildClass))();
+    const instance = new (MockModule(ChildModuleClass))();
     expect(instance).toEqual(jasmine.any(Mock));
     expect(instance.parentMethod()).toBeUndefined('mocked to an empty function');
     expect(instance.childMethod()).toBeUndefined('mocked to an empty function');
   });
 
   it('should affect as MockComponent', () => {
-    const instance = new (MockComponent(ChildClass))();
+    const instance = new (MockComponent(ChildComponentClass))();
     expect(instance).toEqual(jasmine.any(MockControlValueAccessor));
     expect(instance).toEqual(jasmine.any(Mock));
     expect(instance.parentMethod()).toBeUndefined('mocked to an empty function');
@@ -50,7 +93,7 @@ describe('Mock', () => {
   });
 
   it('should affect as MockDirective', () => {
-    const instance = new (MockDirective(ChildClass))();
+    const instance = new (MockDirective(ChildDirectiveClass))();
     expect(instance).toEqual(jasmine.any(MockControlValueAccessor));
     expect(instance).toEqual(jasmine.any(Mock));
     expect(instance.parentMethod()).toBeUndefined('mocked to an empty function');
@@ -58,7 +101,7 @@ describe('Mock', () => {
   });
 
   it('should affect as MockPipe', () => {
-    const instance = new (MockPipe(ChildClass))();
+    const instance = new (MockPipe(ChildPipeClass))();
     expect(instance).toEqual(jasmine.any(Mock));
     expect(instance.parentMethod()).toBeUndefined('mocked to an empty function');
     expect(instance.childMethod()).toBeUndefined('mocked to an empty function');

--- a/lib/common/index.ts
+++ b/lib/common/index.ts
@@ -1,2 +1,3 @@
-export * from './mock-of.decorator';
 export * from './Mock';
+export * from './lib';
+export * from './mock-of.decorator';

--- a/lib/common/lib.ts
+++ b/lib/common/lib.ts
@@ -1,0 +1,150 @@
+import { InjectionToken, ModuleWithProviders, PipeTransform, Type } from '@angular/core';
+import { getTestBed } from '@angular/core/testing';
+
+import { jitReflector } from './reflect';
+
+import { MockedComponent } from '../mock-component';
+import { MockedDirective } from '../mock-directive';
+import { MockedModule } from '../mock-module';
+import { MockedPipe } from '../mock-pipe';
+import { ngMocksUniverse } from './ng-mocks-universe';
+
+export const NG_MOCKS = new InjectionToken<Map<any, any>>('NG_MOCKS');
+
+/**
+ * Can be changed any time.
+ *
+ * @internal
+ */
+export const getNgMocksFromTestBed = (): Map<any, any> | undefined => {
+  const testBed: any = getTestBed();
+  try {
+    return testBed.inject ? testBed.inject(NG_MOCKS) : testBed.get(NG_MOCKS);
+  } catch (e) {
+    return undefined;
+  }
+};
+
+export const flatten = <T>(values: T | T[], result: T[] = []): T[] => {
+  if (Array.isArray(values)) {
+    values.forEach((value: T | T[]) => flatten(value, result));
+  } else {
+    result.push(values);
+  }
+  return result;
+};
+
+export const isNgType = (object: Type<any>, type: string): boolean => jitReflector
+  .annotations(object)
+  .some((annotation) => annotation.ngMetadataName === type);
+
+/**
+ * Checks whether a class was decorated by a ng type.
+ * m - module.
+ * c - component.
+ * d - directive.
+ * p - pipe.
+ */
+export function isNgDef(object: any, ngType: 'm' | 'c' | 'd'): object is Type<any>;
+export function isNgDef(object: any, ngType: 'p'): object is Type<PipeTransform>;
+export function isNgDef(object: any, ngType: string): object is Type<any> {
+  if (ngType === 'm') {
+    return isNgType(object, 'NgModule');
+  }
+  if (ngType === 'c') {
+    return isNgType(object, 'Component');
+  }
+  if (ngType === 'd') {
+    return isNgType(object, 'Directive');
+  }
+  if (ngType === 'p') {
+    return isNgType(object, 'Pipe');
+  }
+  return false;
+}
+
+/**
+ * Checks whether a class is a mock of a class that was decorated by a ng type.
+ * m - module.
+ * c - component.
+ * d - directive.
+ * p - pipe.
+ */
+export function isMockedNgDefOf<T>(object: any, type: Type<T>, ngType: 'm'): object is Type<MockedModule<T>>;
+export function isMockedNgDefOf<T>(object: any, type: Type<T>, ngType: 'c'): object is Type<MockedComponent<T>>;
+export function isMockedNgDefOf<T>(object: any, type: Type<T>, ngType: 'd'): object is Type<MockedDirective<T>>;
+export function isMockedNgDefOf<T extends PipeTransform>(object: any, type: Type<T>, ngType: 'p'):
+  object is Type<MockedPipe<T>>;
+export function isMockedNgDefOf<T>(object: any, type: Type<T>): object is Type<T>;
+export function isMockedNgDefOf<T>(object: any, type: Type<T>, ngType?: any): object is Type<T> {
+  return typeof object === 'function' && object.mockOf === type && (ngType ? isNgDef(object, ngType) : true);
+}
+
+export const isNgInjectionToken = (object: any): object is InjectionToken<any> =>
+  typeof object === 'object' && object.ngMetadataName === 'InjectionToken';
+
+// Checks if an object implements ModuleWithProviders.
+export const isNgModuleDefWithProviders = (object: any):
+  object is ModuleWithProviders => object.ngModule !== undefined
+  && isNgDef(object.ngModule, 'm');
+
+/**
+ * Checks whether an object is an instance of a mocked class that was decorated by a ng type.
+ * m - module.
+ * c - component.
+ * d - directive.
+ * p - pipe.
+ */
+export function isMockOf<T>(object: any, type: Type<T>, ngType: 'm'): object is MockedModule<T>;
+export function isMockOf<T>(object: any, type: Type<T>, ngType: 'c'): object is MockedComponent<T>;
+export function isMockOf<T>(object: any, type: Type<T>, ngType: 'd'): object is MockedDirective<T>;
+export function isMockOf<T extends PipeTransform>(object: any, type: Type<T>, ngType: 'p'):
+  object is MockedPipe<T>;
+export function isMockOf<T>(object: any, type: Type<T>): object is T;
+export function isMockOf<T>(object: any, type: Type<T>, ngType?: any): object is T {
+  return typeof object === 'object'
+    && (ngType ? isMockedNgDefOf(object.constructor, type, ngType) : isMockedNgDefOf(object.constructor, type));
+}
+
+/**
+ * Returns a def of a mocked class based on another mock class or a source class that was decorated by a ng type.
+ * m - module.
+ * c - component.
+ * d - directive.
+ * p - pipe.
+ */
+export function getMockedNgDefOf<T>(type: Type<T>, ngType: 'm'): Type<MockedModule<T>>;
+export function getMockedNgDefOf<T>(type: Type<T>, ngType: 'c'): Type<MockedComponent<T>>;
+export function getMockedNgDefOf<T>(type: Type<T>, ngType: 'd'): Type<MockedDirective<T>>;
+export function getMockedNgDefOf<T>(type: Type<T>, ngType: 'p'): Type<MockedPipe<T>>;
+export function getMockedNgDefOf(type: Type<any>): Type<any>;
+export function getMockedNgDefOf(type: any, ngType?: any): any {
+  const source = type.mockOf ? type.mockOf : type;
+  const mocks = getNgMocksFromTestBed();
+
+  let mock: any;
+
+  // If mocks exists, we are in the MockBuilder env and it's enough for the check.
+  if (mocks && mocks.has(source)) {
+    mock = mocks.get(source);
+  } else if (mocks) {
+    throw new Error(`There is no mock for ${source.name}`);
+  }
+
+  // If we are not in the MockBuilder env we can rely on the current cache.
+  if (!mock && source !== type) {
+    mock = type;
+  } else if (!mock && ngMocksUniverse.cache.has(source)) {
+    mock = ngMocksUniverse.cache.get(source);
+  }
+
+  if (!ngType) {
+    return mock;
+  }
+  if (ngType && isMockedNgDefOf(mock, type, ngType)) {
+    return mock;
+  }
+
+  // Looks like the def hasn't been mocked.
+  throw new Error(`There is no mock for ${source.name}`);
+}

--- a/lib/common/ng-mocks-universe.ts
+++ b/lib/common/ng-mocks-universe.ts
@@ -1,0 +1,14 @@
+import { InjectionToken, Type } from '@angular/core';
+
+/**
+ * Can be changed any time.
+ *
+ * @internal
+ */
+export const ngMocksUniverse = {
+  builder: new Map(),
+  cache: new Map(),
+  config: new Map(),
+  flags: new Set<string>(['cacheModule', 'cacheComponent', 'cacheDirective', 'cacheProvider']),
+  touches: new Set<Type<any> | InjectionToken<any>>(),
+};

--- a/lib/mock-builder/index.ts
+++ b/lib/mock-builder/index.ts
@@ -1,0 +1,1 @@
+export * from './mock-builder';

--- a/lib/mock-builder/mock-builder.ts
+++ b/lib/mock-builder/mock-builder.ts
@@ -1,0 +1,416 @@
+// tslint:disable:unified-signatures
+
+import { InjectionToken, ModuleWithProviders, NgModule, PipeTransform, Provider, Type } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { flatten, isNgDef, isNgInjectionToken, NG_MOCKS } from '../common';
+import { ngMocksUniverse } from '../common/ng-mocks-universe';
+import { MockComponent } from '../mock-component';
+import { MockDirective } from '../mock-directive';
+import { MockModule, MockProvider } from '../mock-module';
+import { MockPipe } from '../mock-pipe';
+
+export interface IMockBuilderResult {
+  testBed: typeof TestBed;
+}
+
+export interface IMockBuilderConfigAll {
+  dependency?: boolean; // won't be added to TestBedModule.
+  export?: boolean; // will be forced for export in its module.
+}
+
+export interface IMockBuilderConfigComponent {
+  render?: {
+    [blockName: string]: boolean | {
+      $implicit?: any;
+      variables?: {[key: string]: any};
+    };
+  };
+}
+
+export interface IMockBuilderConfigDirective {
+  render?: boolean | {
+    $implicit?: any;
+    variables?: {[key: string]: any};
+  };
+}
+
+export type IMockBuilderConfig = IMockBuilderConfigAll | IMockBuilderConfigComponent | IMockBuilderConfigDirective;
+
+const defaultMock = Symbol();
+
+export class MockBuilderPromise implements PromiseLike<IMockBuilderResult> {
+  protected beforeCC: Set<(testBed: typeof TestBed) => void> = new Set();
+  protected configDef: Map<Type<any>, any> = new Map();
+
+  protected keepDef: {
+    component: Set<Type<any>>;
+    directive: Set<Type<any>>;
+    module: Set<Type<any>>;
+    pipe: Set<Type<any & PipeTransform>>;
+    provider: Set<Type<any> | InjectionToken<any>>;
+  } = {
+    component: new Set(),
+    directive: new Set(),
+    module: new Set(),
+    pipe: new Set(),
+    provider: new Set(),
+  };
+
+  protected mockDef: {
+    component: Set<Type<any>>;
+    directive: Set<Type<any>>;
+    module: Set<Type<any>>;
+    pipe: Set<Type<any & PipeTransform>>;
+    pipeTransform: Map<Type<any & PipeTransform>, PipeTransform['transform']>;
+    provider: Set<Type<any> | InjectionToken<any>>;
+    providerMock: Map<Type<any> | InjectionToken<any>, any>;
+  } = {
+    component: new Set(),
+    directive: new Set(),
+    module: new Set(),
+    pipe: new Set(),
+    pipeTransform: new Map(),
+    provider: new Set(),
+    providerMock: new Map(),
+  };
+
+  protected providerDef: Map<Type<any> | InjectionToken<any>, Provider> = new Map();
+
+  protected replaceDef: {
+    component: Map<Type<any>, Type<any>>;
+    directive: Map<Type<any>, Type<any>>;
+    module: Map<Type<any>, Type<any>>;
+    pipe: Map<Type<any & PipeTransform>, Type<any & PipeTransform>>;
+  } = {
+    component: new Map(),
+    directive: new Map(),
+    module: new Map(),
+    pipe: new Map(),
+  };
+
+  public beforeCompileComponents(callback: (testBed: typeof TestBed) => void): this {
+    this.beforeCC.add(callback);
+    return this;
+  }
+
+  public build(): NgModule { // tslint:disable-line:cyclomatic-complexity
+    const backup = {
+      builder: ngMocksUniverse.builder,
+      cache: ngMocksUniverse.cache,
+      config: ngMocksUniverse.config,
+      flags: ngMocksUniverse.flags,
+      touches: ngMocksUniverse.touches,
+    };
+
+    ngMocksUniverse.builder = new Map();
+    ngMocksUniverse.cache = new Map();
+    ngMocksUniverse.config = this.configDef;
+    ngMocksUniverse.flags = new Set([
+      'cacheComponent',
+      'cacheDirective',
+      'cacheModule',
+      'cachePipe',
+      'cacheProvider',
+      'correctModuleExports',
+    ]);
+    ngMocksUniverse.touches = new Set();
+
+    for (const def of [
+      ...this.keepDef.provider.values(),
+      ...this.keepDef.pipe.values(),
+      ...this.keepDef.directive.values(),
+      ...this.keepDef.component.values(),
+      ...this.keepDef.module.values(),
+    ]) {
+      ngMocksUniverse.builder.set(def, def);
+    }
+
+    for (const [source, destination] of [
+      ...this.replaceDef.pipe.entries(),
+      ...this.replaceDef.directive.entries(),
+      ...this.replaceDef.component.entries(),
+      ...this.replaceDef.module.entries(),
+    ]) {
+      ngMocksUniverse.builder.set(source, destination);
+    }
+
+    // mocking requested things.
+    for (const def of this.mockDef.provider.values()) {
+      if (this.mockDef.providerMock.has(def)) {
+        ngMocksUniverse.builder.set(def, {provide: def, useValue: this.mockDef.providerMock.get(def)});
+      } else {
+        ngMocksUniverse.builder.set(def, MockProvider(def));
+      }
+      ngMocksUniverse.touches.delete(def);
+    }
+    for (const def of this.mockDef.pipe.values()) {
+      if (this.mockDef.pipeTransform.has(def)) {
+        ngMocksUniverse.builder.set(def, MockPipe(def, this.mockDef.pipeTransform.get(def)));
+      } else {
+        ngMocksUniverse.builder.set(def, MockPipe(def));
+      }
+      ngMocksUniverse.touches.delete(def);
+    }
+    for (const def of this.mockDef.directive.values()) {
+      ngMocksUniverse.builder.set(def, MockDirective(def));
+      ngMocksUniverse.touches.delete(def);
+    }
+    for (const def of this.mockDef.component.values()) {
+      ngMocksUniverse.builder.set(def, MockComponent(def));
+      ngMocksUniverse.touches.delete(def);
+    }
+
+    // Now we need to run through requested modules.
+    for (const def of [
+      ...this.mockDef.module.values(),
+      ...this.keepDef.module.values(),
+      ...this.replaceDef.module.keys(),
+    ]) {
+      ngMocksUniverse.builder.set(def, MockModule(def));
+      ngMocksUniverse.touches.delete(def);
+    }
+
+    // Setting up TestBed.
+    const imports: Array<Type<any> | ModuleWithProviders> = [];
+
+    // Adding suitable leftovers.
+    for (const def of [
+      ...this.mockDef.module.values(),
+      ...this.keepDef.module.values(),
+      ...this.replaceDef.module.keys(),
+    ]) {
+      if (ngMocksUniverse.touches.has(def)) {
+        continue;
+      }
+      const config = this.configDef.get(def);
+      if (config && config.dependency) {
+        continue;
+      }
+      imports.push(ngMocksUniverse.builder.get(def));
+    }
+
+    const declarations: Array<Type<any>> = [];
+
+    // adding missed declarations to test bed.
+    for (const def of [
+      ...this.keepDef.pipe.values(),
+      ...this.keepDef.directive.values(),
+      ...this.keepDef.component.values(),
+      ...this.replaceDef.pipe.keys(),
+      ...this.replaceDef.directive.keys(),
+      ...this.replaceDef.component.keys(),
+      ...this.mockDef.pipe.values(),
+      ...this.mockDef.directive.values(),
+      ...this.mockDef.component.values(),
+    ]) {
+      if (ngMocksUniverse.touches.has(def)) {
+        continue;
+      }
+      const config = this.configDef.get(def);
+      if (config && config.dependency) {
+        continue;
+      }
+      declarations.push(ngMocksUniverse.builder.get(def));
+    }
+
+    const providers: Provider[] = [];
+
+    // Adding missed providers to test bed.
+    for (const def of this.keepDef.provider.values()) {
+      if (ngMocksUniverse.touches.has(def)) {
+        continue;
+      }
+      providers.push(isNgInjectionToken(def) ? {
+        provide: def,
+        useValue: undefined,
+      } : def);
+    }
+
+    // Adding missed providers to test bed.
+    for (const def of this.mockDef.provider.values()) {
+      if (ngMocksUniverse.touches.has(def)) {
+        continue;
+      }
+      providers.push(ngMocksUniverse.builder.get(def));
+    }
+
+    // Adding requested providers to test bed.
+    for (const provider of this.providerDef.values()) {
+      if (!provider) {
+        continue;
+      }
+      providers.push(provider);
+    }
+
+    const ngMocks = new Map();
+    for (const [key, value] of [
+      ...ngMocksUniverse.builder.entries(),
+      ...ngMocksUniverse.cache.entries(),
+    ]) {
+      ngMocks.set(key, value);
+    }
+
+    providers.push({
+      provide: NG_MOCKS,
+      useValue: ngMocks,
+    });
+
+    Object.assign(ngMocksUniverse, backup);
+
+    return {
+      declarations,
+      imports,
+      providers,
+    };
+  }
+
+  public keep(def: any, config?: IMockBuilderConfig): this {
+    if (isNgDef(def, 'm')) {
+      this.mockDef.module.delete(def);
+      this.replaceDef.module.delete(def);
+      this.keepDef.module.add(def);
+    } else if (isNgDef(def, 'c')) {
+      this.mockDef.component.delete(def);
+      this.replaceDef.component.delete(def);
+      this.keepDef.component.add(def);
+    } else if (isNgDef(def, 'd')) {
+      this.mockDef.directive.delete(def);
+      this.replaceDef.directive.delete(def);
+      this.keepDef.directive.add(def);
+    } else if (isNgDef(def, 'p')) {
+      this.mockDef.pipe.delete(def);
+      this.mockDef.pipeTransform.delete(def);
+      this.replaceDef.pipe.delete(def);
+      this.keepDef.pipe.add(def);
+    } else {
+      this.mockDef.provider.delete(def);
+      this.mockDef.providerMock.delete(def);
+      this.providerDef.delete(def);
+      this.keepDef.provider.add(def);
+    }
+    if (config) {
+      this.configDef.set(def, config);
+    } else {
+      this.configDef.delete(def);
+    }
+    return this;
+  }
+
+  public mock(pipe: Type<PipeTransform>, config?: IMockBuilderConfig): this;
+  public mock(pipe: Type<PipeTransform>, mock?: PipeTransform['transform'], config?: IMockBuilderConfig): this;
+  public mock<T>(token: InjectionToken<T>, mock?: any): this;
+  public mock<T>(def: Type<T>, mock: IMockBuilderConfig): this;
+  public mock<T>(provider: Type<T>, mock?: any): this;
+  public mock<T>(def: Type<T>): this;
+  public mock(def: any, a1: any = defaultMock, a2?: any): this {
+    let mock: any = a1;
+    let config: any = a1 === defaultMock ? undefined : a1;
+    if (isNgDef(def, 'p') && typeof a1 === 'function') {
+      mock = a1;
+      config = a2;
+    }
+
+    if (isNgDef(def, 'm')) {
+      this.keepDef.module.delete(def);
+      this.replaceDef.module.delete(def);
+      this.mockDef.module.add(def);
+    } else if (isNgDef(def, 'c')) {
+      this.keepDef.component.delete(def);
+      this.replaceDef.component.delete(def);
+      this.mockDef.component.add(def);
+    } else if (isNgDef(def, 'd')) {
+      this.keepDef.directive.delete(def);
+      this.replaceDef.directive.delete(def);
+      this.mockDef.directive.add(def);
+    } else if (isNgDef(def, 'p')) {
+      this.keepDef.pipe.delete(def);
+      this.replaceDef.pipe.delete(def);
+      this.mockDef.pipe.add(def);
+      if (typeof mock === 'function') {
+        this.mockDef.pipeTransform.set(def, mock);
+      }
+    } else {
+      this.keepDef.provider.delete(def);
+      this.providerDef.delete(def);
+      this.mockDef.provider.add(def);
+      if (mock !== defaultMock) {
+        this.mockDef.providerMock.set(def, mock);
+      }
+      config = undefined;
+    }
+    if (config) {
+      this.configDef.set(def, config);
+    } else {
+      this.configDef.delete(def);
+    }
+    return this;
+  }
+
+  public provide(def: Provider): this {
+    for (const provider of flatten(def)) {
+      const provide = typeof provider === 'object' && provider.provide ? provider.provide : provider;
+      this.keepDef.provider.delete(provide);
+      this.mockDef.provider.delete(provide);
+      this.providerDef.set(provide, provider);
+    }
+    return this;
+  }
+
+  public replace(source: Type<any>, destination: Type<any>, config?: IMockBuilderConfig): this {
+    if (isNgDef(source, 'm') && isNgDef(destination, 'm')) {
+      this.keepDef.module.delete(source);
+      this.mockDef.module.delete(source);
+      this.replaceDef.module.set(source, destination);
+    } else if (isNgDef(source, 'c') && isNgDef(destination, 'c')) {
+      this.keepDef.component.delete(source);
+      this.mockDef.component.delete(source);
+      this.replaceDef.component.set(source, destination);
+    } else if (isNgDef(source, 'd') && isNgDef(destination, 'd')) {
+      this.keepDef.directive.delete(source);
+      this.mockDef.directive.delete(source);
+      this.replaceDef.directive.set(source, destination);
+    } else if (isNgDef(source, 'p') && isNgDef(destination, 'p')) {
+      this.keepDef.pipe.delete(source);
+      this.mockDef.pipe.delete(source);
+      this.replaceDef.pipe.set(source, destination);
+    } else {
+      throw new Error('cannot replace the source by destination destination, wrong types');
+    }
+    if (config) {
+      this.configDef.set(source, config);
+    } else {
+      this.configDef.delete(source);
+    }
+    return this;
+  }
+
+  public then<TResult1 = IMockBuilderResult, TResult2 = never>(
+    fulfill?: ((value: IMockBuilderResult) => (PromiseLike<TResult1> | TResult1)) | undefined | null,
+    reject?: ((reason: any) => (PromiseLike<TResult2> | TResult2)) | undefined | null,
+  ): PromiseLike<TResult1 | TResult2> {
+    const promise = new Promise((resolve: (value: IMockBuilderResult) => void): void => {
+      const testBed = TestBed.configureTestingModule(this.build());
+      for (const callback of this.beforeCC.values()) {
+        callback(testBed);
+      }
+      testBed.compileComponents().then(() => {
+        resolve({testBed});
+      });
+    });
+    return promise.then(fulfill, reject);
+  }
+}
+
+export function MockBuilder(componentToTest?: Type<any>, itsModuleToMock?: Type<any>): MockBuilderPromise {
+  const instance = new MockBuilderPromise();
+  if (componentToTest) {
+    instance.keep(componentToTest, {
+      export: true,
+    });
+  }
+  if (itsModuleToMock) {
+    instance.mock(itsModuleToMock);
+  }
+  return instance;
+}

--- a/lib/mock-component/mock-component.spec.ts
+++ b/lib/mock-component/mock-component.spec.ts
@@ -2,16 +2,18 @@ import { Component, DebugElement, ViewChild } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { MockedDirective, MockHelper } from 'ng-mocks';
 
-import { staticTrue } from '../../tests';
-import { MockComponent, MockComponents, MockedComponent } from './mock-component';
+import { MockComponent, MockComponents, MockedComponent } from '.';
 import { ChildComponent } from './test-components/child-component.component';
 import { CustomFormControlComponent } from './test-components/custom-form-control.component';
 import { EmptyComponent } from './test-components/empty-component.component';
 import { GetterSetterComponent } from './test-components/getter-setter.component';
 import { SimpleComponent } from './test-components/simple-component.component';
 import { TemplateOutletComponent } from './test-components/template-outlet.component';
+
+import { staticTrue } from '../../tests';
+import { MockedDirective } from '../mock-directive';
+import { MockHelper } from '../mock-helper';
 
 @Component({
   selector: 'example-component-container',

--- a/lib/mock-declaration/mock-declaration.ts
+++ b/lib/mock-declaration/mock-declaration.ts
@@ -1,23 +1,26 @@
 import { Type } from '@angular/core';
+import { MockComponent, MockedComponent } from '../mock-component';
+import { MockDirective, MockedDirective } from '../mock-directive';
+import { MockedPipe, MockPipe } from '../mock-pipe';
 
-import { jitReflector, pipeResolver } from '../common/reflect';
-import { MockComponent } from '../mock-component';
-import { MockDirective } from '../mock-directive';
-import { MockPipe } from '../mock-pipe';
+import { isNgDef } from '../common';
 
 export function MockDeclarations(...declarations: Array<Type<any>>): Array<Type<any>> {
   return declarations.map(MockDeclaration);
 }
 
-export function MockDeclaration(declaration: Type<any>): Type<any> {
-  if (pipeResolver.isPipe(declaration)) {
-    return MockPipe(declaration as any) as any;
+export function MockDeclaration<T>(
+  declaration: Type<T>,
+): Type<MockedPipe<T> | MockedDirective<T> | MockedComponent<T>> {
+  if (isNgDef(declaration, 'p')) {
+    // TODO remove any when support of A5 has been stopped.
+    return MockPipe(declaration) as any;
   }
-
-  const annotations = jitReflector.annotations(declaration);
-  if (annotations.find((annotation) => annotation.template !== undefined || annotation.templateUrl !== undefined)) {
-    return MockComponent(declaration) as any;
+  if (isNgDef(declaration, 'c')) {
+    return MockComponent(declaration);
   }
-
-  return MockDirective(declaration) as any;
+  if (isNgDef(declaration, 'd')) {
+    return MockDirective(declaration);
+  }
+  return declaration;
 }

--- a/lib/mock-directive/mock-directive.spec.ts
+++ b/lib/mock-directive/mock-directive.spec.ts
@@ -2,10 +2,10 @@ import { Component, Directive, EventEmitter, Input, Output, ViewChild } from '@a
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, FormControlDirective } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { MockedDirective, MockHelper } from 'ng-mocks';
 
+import { MockDirective, MockedDirective } from '.';
 import { staticFalse } from '../../tests';
-import { MockDirective } from './mock-directive';
+import { MockHelper } from '../mock-helper';
 
 // tslint:disable:max-classes-per-file
 @Directive({

--- a/lib/mock-directive/mock-directive.ts
+++ b/lib/mock-directive/mock-directive.ts
@@ -1,9 +1,18 @@
-import { Directive, ElementRef, forwardRef, Optional, TemplateRef, Type, ViewContainerRef } from '@angular/core';
+import {
+  Directive,
+  ElementRef,
+  forwardRef,
+  OnInit,
+  Optional,
+  TemplateRef,
+  Type,
+  ViewContainerRef,
+} from '@angular/core';
+import { getTestBed } from '@angular/core/testing';
 
-import { MockControlValueAccessor, MockOf } from '../common';
+import { getMockedNgDefOf, MockControlValueAccessor, MockOf } from '../common';
+import { ngMocksUniverse } from '../common/ng-mocks-universe';
 import { directiveResolver } from '../common/reflect';
-
-const cache = new Map<Type<Directive>, Type<MockedDirective<Directive>>>();
 
 export type MockedDirective<T> = T & MockControlValueAccessor & {
   /** Pointer to current element in case of Attribute Directives. */
@@ -26,14 +35,19 @@ export function MockDirectives(...directives: Array<Type<any>>): Array<Type<Mock
   return directives.map(MockDirective);
 }
 
-export function MockDirective<TDirective>(directive: Type<TDirective>): Type<MockedDirective<TDirective>> {
-  const cacheHit = cache.get(directive);
-  if (cacheHit) {
-    return cacheHit as Type<MockedDirective<TDirective>>;
+export function MockDirective<TDirective>(
+  directive: Type<TDirective>,
+): Type<MockedDirective<TDirective>> {
+  // We are inside of an 'it'.
+  // It's fine to to return a mock or to throw an exception if it wasn't mocked in TestBed.
+  if ((getTestBed() as any)._instantiated) {
+    return getMockedNgDefOf(directive, 'd');
+  }
+  if (ngMocksUniverse.flags.has('cacheDirective') && ngMocksUniverse.cache.has(directive)) {
+    return ngMocksUniverse.cache.get(directive);
   }
 
   const { selector, exportAs, inputs, outputs } = directiveResolver.resolve(directive);
-
   const options: Directive = {
     exportAs,
     inputs,
@@ -45,8 +59,10 @@ export function MockDirective<TDirective>(directive: Type<TDirective>): Type<Moc
     selector,
   };
 
+  const config = ngMocksUniverse.config.get(directive);
+
   @MockOf(directive, outputs)
-  class DirectiveMock extends MockControlValueAccessor {
+  class DirectiveMock extends MockControlValueAccessor implements OnInit {
     constructor(
       @Optional() element?: ElementRef,
       @Optional() template?: TemplateRef<any>,
@@ -69,10 +85,22 @@ export function MockDirective<TDirective>(directive: Type<TDirective>): Type<Moc
         }
       };
     }
+
+    ngOnInit(): void {
+      if (config && config.render) {
+        const { $implicit, variables } = config.render !== true ? config.render : {
+          $implicit: undefined,
+          variables: {},
+        };
+        (this as any).__render($implicit, variables);
+      }
+    }
   }
 
   const mockedDirective: Type<MockedDirective<TDirective>> = Directive(options)(DirectiveMock as any);
-  cache.set(directive, mockedDirective);
+  if (ngMocksUniverse.flags.has('cacheDirective')) {
+    ngMocksUniverse.cache.set(directive, mockedDirective);
+  }
 
   return mockedDirective;
 }

--- a/lib/mock-module/mock-module.spec.ts
+++ b/lib/mock-module/mock-module.spec.ts
@@ -5,7 +5,6 @@ import { Component } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserModule, By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { MockComponent, MockModule, MockRender } from 'ng-mocks';
 
 import {
   AppRoutingModule, CustomWithServiceComponent,
@@ -18,6 +17,10 @@ import {
   SameImports1Module,
   SameImports2Module, WithServiceModule,
 } from './test-fixtures';
+
+import { MockModule } from '.';
+import { MockComponent } from '../mock-component';
+import { MockRender } from '../mock-render';
 
 @Component({
   selector: 'component-subject',

--- a/lib/mock-render/mock-render.fixtures.ts
+++ b/lib/mock-render/mock-render.fixtures.ts
@@ -1,3 +1,5 @@
+// tslint:disable:max-classes-per-file
+
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 
 @Component({
@@ -7,4 +9,10 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 export class RenderRealComponent {
   @Output() click = new EventEmitter<{}>();
   @Input() content = '';
+}
+
+@Component({
+  template: 'WithoutSelectorComponent',
+})
+export class WithoutSelectorComponent {
 }

--- a/lib/mock-render/mock-render.spec.ts
+++ b/lib/mock-render/mock-render.spec.ts
@@ -3,14 +3,15 @@ import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { MockRender } from './mock-render';
-import { RenderRealComponent } from './mock-render.fixtures';
+import { RenderRealComponent, WithoutSelectorComponent } from './mock-render.fixtures';
 
 describe('MockRender', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [
-        RenderRealComponent
+        RenderRealComponent,
+        WithoutSelectorComponent,
       ]
     });
   });
@@ -65,5 +66,10 @@ describe('MockRender', () => {
     expect(fixture.debugElement.nativeElement.innerText).not.toContain('injected content');
     fixture.detectChanges();
     expect(fixture.debugElement.nativeElement.innerText).toContain('injected content');
+  });
+
+  it('does not render a component without selector', () => {
+    const fixture = MockRender(WithoutSelectorComponent);
+    expect(fixture.debugElement.nativeElement.innerHTML).toEqual('');
   });
 });

--- a/lib/mock-render/mock-render.ts
+++ b/lib/mock-render/mock-render.ts
@@ -13,8 +13,8 @@ function MockRender<MComponent, TComponent extends {[key: string]: any}>(
     mockedTemplate = template;
   } else {
     const {inputs, outputs, selector} = directiveResolver.resolve(template);
-    mockedTemplate += `<${selector}`;
-    if (inputs) {
+    mockedTemplate += selector ? `<${selector}` : '';
+    if (selector && inputs) {
       inputs.forEach((definition: string) => {
         const [property, alias] = definition.split(': ');
         if (alias && params && typeof params[alias]) {
@@ -24,7 +24,7 @@ function MockRender<MComponent, TComponent extends {[key: string]: any}>(
         }
       });
     }
-    if (outputs) {
+    if (selector && outputs) {
       outputs.forEach((definition: string) => {
         const [property, alias] = definition.split(': ');
         if (alias && params && typeof params[alias]) {
@@ -34,7 +34,7 @@ function MockRender<MComponent, TComponent extends {[key: string]: any}>(
         }
       });
     }
-    mockedTemplate += `></${selector}>`;
+    mockedTemplate += selector ? `></${selector}>` : '';
   }
   const options: Component = {
     selector: 'mock-render',

--- a/lib/mock-service/mock-service.spec.ts
+++ b/lib/mock-service/mock-service.spec.ts
@@ -1,6 +1,7 @@
-import { MockService } from 'ng-mocks';
-
 // tslint:disable:max-classes-per-file
+
+import { MockService } from '.';
+
 class DeepParentClass {
   public deepParentMethodName = 'deepParentMethod';
 


### PR DESCRIPTION
A `MockBuilder` to facilitate a creation of a NgModule for the TestBed.

- [x] Rebase after #86.
- [x] Rebase after #88.
- [x] Add a module replacement.
- [x] Add a component replacement.
- [x] Add a directive replacement.
- [x] Add a pipe replacement.
- [x] Add a config for modules to keep it as a dependency (no import to test bed).
- [x] Add a config for components to keep it as a dependency (no import to test bed).
- [x] Add a config for directives to keep it as a dependency (no import to test bed).
- [x] Add a config for pipes to keep it as a dependency (no import to test bed).
- [x] Add a config for the structural directives render rules.
- [x] Add a config for the contentChild render rules.
- [x] Check how 2 kept modules import another kept module with a mocked component.
- [x] Add and check support of an internal vs external module (proper exports).
- [x] Write a proper readme text.
- [x] Cover a case when a module is exported but wasn't imported.
- [x] Check provider deps for the replacement.

How to use can be found in its readme: https://github.com/satanTime/ng-mocks/tree/issues/44#mockbuilder

Closes #44
Closes #60
Closes #70