### PR TITLE
fix: never mock ApplicationModule

### DIFF
--- a/lib/mock-module/mock-module.spec.ts
+++ b/lib/mock-module/mock-module.spec.ts
@@ -1,13 +1,14 @@
 /* tslint:disable:max-classes-per-file */
 
 import { CommonModule } from '@angular/common';
-import { Component } from '@angular/core';
+import { ApplicationModule, Component } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserModule, By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import {
-  AppRoutingModule, CustomWithServiceComponent,
+  AppRoutingModule,
+  CustomWithServiceComponent,
   ExampleComponent,
   ExampleConsumerComponent,
   LogicNestedModule,
@@ -15,7 +16,8 @@ import {
   ModuleWithProvidersModule,
   ParentModule,
   SameImports1Module,
-  SameImports2Module, WithServiceModule,
+  SameImports2Module,
+  WithServiceModule,
 } from './test-fixtures';
 
 import { MockModule } from '.';
@@ -103,9 +105,10 @@ describe('NeverMockModules', () => {
         SameImportsComponent
       ],
       imports: [
-        MockModule(CommonModule),
-        MockModule(BrowserModule),
+        MockModule(ApplicationModule),
         MockModule(BrowserAnimationsModule),
+        MockModule(BrowserModule),
+        MockModule(CommonModule),
       ],
     })
     .compileComponents()

--- a/lib/mock-module/mock-module.ts
+++ b/lib/mock-module/mock-module.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { ModuleWithProviders, NgModule, Provider, Type } from '@angular/core';
+import { ApplicationModule, ModuleWithProviders, NgModule, Provider, Type } from '@angular/core';
 import { getTestBed } from '@angular/core/testing';
 
 import { flatten, getMockedNgDefOf, isNgDef, isNgModuleDefWithProviders, Mock, MockOf } from '../common';
@@ -15,9 +15,8 @@ export type MockedModule<T> = T & Mock & {};
 // Some modules inject own providers, which don't allow mocks due to conflicts with test env.
 // We have to avoid any injection of those providers to mock everything properly.
 const neverMockProvidedToken = [
-  // RouterModule
-  'InjectionToken Application Initializer',
   // BrowserModule
+  'InjectionToken Application Initializer',
   'InjectionToken EventManagerPlugins',
   'InjectionToken HammerGestureConfig',
 ];
@@ -148,7 +147,7 @@ export function MockModule(module: any): any { // tslint:disable-line:cyclomatic
     : mockModule;
 }
 
-const NEVER_MOCK: Array<Type<any>> = [CommonModule];
+const NEVER_MOCK: Array<Type<any>> = [CommonModule, ApplicationModule];
 
 // tslint:disable-next-line:cyclomatic-complexity
 function MockNgModuleDef(ngModuleDef: NgModule, ngModule?: Type<any>): [boolean, NgModule] {


### PR DESCRIPTION
It has sensetive providers such as:
* Application Initializer
* ApplicationInitStatus
* localeId