### PR TITLE
feat: typecasted MockRender

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,12 @@ describe('MockModule', () => {
 
 Providers simple way to render anything, change `@Inputs` and `@Outputs` of testing component, directives etc.
 
+It returns `fixture` with a `point` property if a component class was passed.
+The `fixture` belongs the middle component for the render,
+when `fixture.point` points to the debug element of the testing component.
+
+The best thing here is that `fixture.point.componentInstance` is typed to the component's class.
+
 ### Usage Example
 
 ```typescript
@@ -419,8 +425,7 @@ describe('MockRender', () => {
     });
 
     // assert on some side effect
-    const componentInstance = fixture.debugElement.query(By.directive(TestedComponent))
-      .componentInstance as TestedComponent;
+    const componentInstance = fixture.point.componentInstance; // it is not any, it is TestedComponent.
     componentInstance.trigger.emit('foo2');
     expect(componentInstance.value1).toEqual('something2');
     expect(componentInstance.value2).toBeUndefined();

--- a/examples/MockRender/MockRender.spec.ts
+++ b/examples/MockRender/MockRender.spec.ts
@@ -50,8 +50,7 @@ describe('MockRender', () => {
     });
 
     // assert on some side effect
-    const componentInstance = fixture.debugElement.query(By.directive(TestedComponent))
-      .componentInstance as TestedComponent;
+    const componentInstance = fixture.point.componentInstance; // it is not any, it is TestedComponent.
     componentInstance.trigger.emit('foo2');
     expect(componentInstance.value1).toEqual('something2');
     expect(componentInstance.value2).toBeUndefined();

--- a/lib/mock-render/mock-render.spec.ts
+++ b/lib/mock-render/mock-render.spec.ts
@@ -63,4 +63,29 @@ describe('MockRender', () => {
     fixture.detectChanges();
     expect(fixture.debugElement.nativeElement.innerText).toContain('injected content');
   });
+
+  it('binds inputs and outputs with a provided component', () => {
+    const spy = createSpy('click');
+    const fixture = MockRender(RenderRealComponent, {
+      click: spy,
+      content: 'content',
+    });
+    expect(spy).not.toHaveBeenCalled();
+    const payload = {
+      value: 'my very random string',
+    };
+    fixture.point.componentInstance.click.emit(payload);
+    expect(spy).toHaveBeenCalledWith(payload);
+  });
+
+  it('does not return a pointer with a provided template', () => {
+    const fixture = MockRender(`<render-real-component></render-real-component>`);
+    // because template can include more than 1 component, be wrapped by any html element etc.
+    expect((fixture as any).point).toBeUndefined();
+  });
+
+  it('returns pointer with a provided component', () => {
+    const fixture = MockRender(RenderRealComponent);
+    expect(fixture.point.componentInstance).toEqual(jasmine.any(RenderRealComponent));
+  });
 });

--- a/lib/mock-render/mock-render.ts
+++ b/lib/mock-render/mock-render.ts
@@ -1,7 +1,54 @@
-import { Component, Type } from '@angular/core';
+// tslint:disable:unified-signatures
+
+import { Component, DebugElement, Type } from '@angular/core';
 import { ComponentFixture, getTestBed, TestBed } from '@angular/core/testing';
 
 import { directiveResolver } from '../common/reflect';
+
+// A5 and its TS 2.4 don't support Omit, that's why we need the magic below.
+// TODO remove it once A5 isn't supported.
+export type DebugElementField =
+  | 'attributes'
+  | 'childNodes'
+  | 'children'
+  | 'classes'
+  | 'context'
+  | 'injector'
+  | 'listeners'
+  | 'name'
+  | 'nativeElement'
+  | 'nativeNode'
+  | 'parent'
+  | 'properties'
+  | 'providerTokens'
+  | 'query'
+  | 'queryAll'
+  | 'queryAllNodes'
+  | 'references'
+  | 'styles'
+  | 'triggerEventHandler';
+
+export type DebugElementType<T> = { componentInstance: T } & Pick<DebugElement, DebugElementField>;
+
+function MockRender<MComponent, TComponent extends { [key: string]: any }>(
+  template: Type<MComponent>,
+  params: TComponent,
+  detectChanges?: boolean
+): ComponentFixture<TComponent> & { point: DebugElementType<MComponent> };
+
+// without params we shouldn't autocomplete any keys of any types.
+function MockRender<MComponent>(
+  template: Type<MComponent>
+): ComponentFixture<null> & { point: DebugElementType<MComponent> };
+
+function MockRender<MComponent, TComponent extends { [key: string]: any }>(
+  template: string,
+  params: TComponent,
+  detectChanges?: boolean
+): ComponentFixture<TComponent>;
+
+// without params we shouldn't autocomplete any keys of any types.
+function MockRender<MComponent>(template: string): ComponentFixture<null>;
 
 function MockRender<MComponent, TComponent extends { [key: string]: any }>(
   template: string | Type<MComponent>,
@@ -58,12 +105,15 @@ function MockRender<MComponent, TComponent extends { [key: string]: any }>(
     declarations: [component],
   });
 
-  const fixture = TestBed.createComponent(component);
+  const fixture: any = TestBed.createComponent(component);
 
   if (detectChanges) {
     fixture.detectChanges();
   }
 
+  if (typeof template !== 'string') {
+    fixture.point = fixture.debugElement.children[0];
+  }
   return fixture;
 }
 


### PR DESCRIPTION
now `MockRender` returns a `fixture` with a `point` property that simplifies typecheck while accessing the component instance.