### PR TITLE
test: assure no leftovers after MockBuilder

### DIFF
--- a/e2e/normal-usage-after-mock-builder/fixtures.components.ts
+++ b/e2e/normal-usage-after-mock-builder/fixtures.components.ts
@@ -1,0 +1,30 @@
+// tslint:disable:max-classes-per-file
+
+import { Component } from '@angular/core';
+import { TargetService } from './fixtures.services';
+
+@Component({
+  selector: 'root',
+  template: '<internal></internal>{{ service.called }}',
+})
+export class TargetComponent {
+  public readonly service: TargetService;
+
+  constructor(service: TargetService) {
+    this.service = service;
+  }
+}
+
+@Component({
+  selector: 'internal',
+  template: 'real',
+})
+export class RealComponent {
+}
+
+@Component({
+  selector: 'internal',
+  template: 'fake',
+})
+export class FakeComponent {
+}

--- a/e2e/normal-usage-after-mock-builder/fixtures.modules.ts
+++ b/e2e/normal-usage-after-mock-builder/fixtures.modules.ts
@@ -1,0 +1,27 @@
+// tslint:disable:max-classes-per-file
+
+import { NgModule } from '@angular/core';
+
+import { RealComponent, TargetComponent } from './fixtures.components';
+import { TargetService } from './fixtures.services';
+
+@NgModule({
+  declarations: [
+    TargetComponent,
+    RealComponent,
+  ],
+  exports: [
+    TargetComponent,
+  ],
+  providers: [
+    TargetService,
+  ],
+})
+export class TargetModule {
+  protected service: TargetService;
+
+  constructor(service: TargetService) {
+    this.service = service;
+    this.service.call();
+  }
+}

--- a/e2e/normal-usage-after-mock-builder/fixtures.services.ts
+++ b/e2e/normal-usage-after-mock-builder/fixtures.services.ts
@@ -1,0 +1,12 @@
+// tslint:disable:max-classes-per-file
+
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class TargetService {
+  public called = 0;
+
+  public call(): void {
+    this.called += 1;
+  }
+}

--- a/e2e/normal-usage-after-mock-builder/test.spec.ts
+++ b/e2e/normal-usage-after-mock-builder/test.spec.ts
@@ -1,0 +1,41 @@
+import { TestBed } from '@angular/core/testing';
+import { MockBuilder, MockRender } from 'ng-mocks';
+
+import { FakeComponent, RealComponent, TargetComponent } from './fixtures.components';
+import { TargetModule } from './fixtures.modules';
+
+describe('normal-usage-after-mock-builder:real1', () => {
+  beforeEach(() => TestBed.configureTestingModule({
+    imports: [TargetModule],
+  }).compileComponents());
+
+  it('renders real component because we did not use MockBuilder.replace yet', () => {
+    const fixture = MockRender(TargetComponent);
+    expect(fixture.debugElement.nativeElement.innerHTML).toEqual('<root><internal>real</internal>1</root>');
+  });
+});
+
+describe('normal-usage-after-mock-builder:mock', () => {
+  beforeEach(() => TestBed.configureTestingModule(
+    MockBuilder()
+      .keep(TargetModule)
+      .replace(RealComponent, FakeComponent, {dependency: true})
+      .build()
+  ).compileComponents());
+
+  it('renders fake component because we used MockBuilder.replace', () => {
+    const fixture = MockRender(TargetComponent);
+    expect(fixture.debugElement.nativeElement.innerHTML).toEqual('<root><internal>fake</internal>1</root>');
+  });
+});
+
+describe('normal-usage-after-mock-builder:real2', () => {
+  beforeEach(() => TestBed.configureTestingModule({
+    imports: [TargetModule],
+  }).compileComponents());
+
+  it('has to render real component after MockBuilder.replace', () => {
+    const fixture = MockRender(TargetComponent);
+    expect(fixture.debugElement.nativeElement.innerHTML).toEqual('<root><internal>real</internal>1</root>');
+  });
+});

--- a/lib/mock-module/mock-module.ts
+++ b/lib/mock-module/mock-module.ts
@@ -119,9 +119,11 @@ export function MockModule(module: any): any { // tslint:disable-line:cyclomatic
   }
 
   if (mockModuleDef) {
+    const parent = ngMocksUniverse.flags.has('skipMock') ? ngModule : Mock;
+
     @NgModule(mockModuleDef)
     @MockOf(ngModule)
-    class ModuleMock extends Mock {
+    class ModuleMock extends parent {
     }
 
     mockModule = ModuleMock;


### PR DESCRIPTION
In case of the skipMock we should respect the original class.