### PR TITLE
feat(mock-builder): ApplicationModule providers

### DIFF
--- a/e2e/mock-builder-keeps-application-module/fixtures.components.ts
+++ b/e2e/mock-builder-keeps-application-module/fixtures.components.ts
@@ -1,0 +1,10 @@
+// tslint:disable:max-classes-per-file
+
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'target-component',
+  template: 'target',
+})
+export class TargetComponent {
+}

--- a/e2e/mock-builder-keeps-application-module/fixtures.modules.ts
+++ b/e2e/mock-builder-keeps-application-module/fixtures.modules.ts
@@ -1,0 +1,26 @@
+// tslint:disable:max-classes-per-file
+
+import { APP_ID, InjectionToken, NgModule } from '@angular/core';
+import { TargetComponent } from './fixtures.components';
+
+export const TARGET_TOKEN = new InjectionToken('TARGET_TOKEN');
+
+@NgModule({
+  declarations: [
+    TargetComponent,
+  ],
+  exports: [
+    TargetComponent,
+  ],
+  providers: [
+    {
+      provide: TARGET_TOKEN,
+      useValue: 'TARGET_TOKEN',
+    },
+    {
+      provide: APP_ID,
+      useValue: 'random',
+    }
+  ],
+})
+export class TargetModule {}

--- a/e2e/mock-builder-keeps-application-module/test.spec.ts
+++ b/e2e/mock-builder-keeps-application-module/test.spec.ts
@@ -1,0 +1,35 @@
+import { APP_ID, APP_INITIALIZER } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { MockBuilder, MockRender } from 'ng-mocks';
+
+import { TargetComponent } from './fixtures.components';
+import { TARGET_TOKEN, TargetModule } from './fixtures.modules';
+
+describe('MockBuilderKeepsApplicationModule:real', () => {
+  beforeEach(() => TestBed.configureTestingModule({
+    imports: [TargetModule],
+  }).compileComponents());
+
+  it('should render', () => {
+    const fixture = MockRender(TargetComponent);
+    const element = fixture.debugElement.query(By.directive(TargetComponent));
+    expect(element).toBeDefined();
+    expect(TestBed.get(TARGET_TOKEN)).toBeDefined();
+    expect(TestBed.get(APP_INITIALIZER)).toBeDefined();
+    expect(TestBed.get(APP_ID)).toBeDefined();
+  });
+});
+
+describe('MockBuilderKeepsApplicationModule:mock', () => {
+  beforeEach(() => MockBuilder(TargetComponent, TargetModule));
+
+  it('should render', () => {
+    const fixture = MockRender(TargetComponent);
+    const element = fixture.debugElement.query(By.directive(TargetComponent));
+    expect(element).toBeDefined();
+    expect(TestBed.get(TARGET_TOKEN)).toBeUndefined();
+    expect(TestBed.get(APP_INITIALIZER)).toBeDefined();
+    expect(TestBed.get(APP_ID)).toBeDefined();
+  });
+});


### PR DESCRIPTION
By default all providers of ApplicationModule will be kept until they're explicitly mocked / replaced.