### PR TITLE
feat: allow to get control value from MockControlValueAccessor

### DIFF
--- a/lib/common/Mock.ts
+++ b/lib/common/Mock.ts
@@ -57,6 +57,8 @@ export class Mock {
 }
 
 export class MockControlValueAccessor extends Mock implements ControlValueAccessor {
+  __value: any; // tslint:disable-line:variable-name
+
   get __ngMocksMockControlValueAccessor(): boolean {
     return true;
   }
@@ -73,5 +75,7 @@ export class MockControlValueAccessor extends Mock implements ControlValueAccess
     this.__simulateTouch = fn;
   }
 
-  writeValue = () => {};
+  writeValue(value: any) {
+    this.__value = value;
+  }
 }

--- a/lib/mock-component/mock-component.spec.ts
+++ b/lib/mock-component/mock-component.spec.ts
@@ -194,6 +194,15 @@ describe('MockComponent', () => {
       customFormControl.__simulateChange('foo');
       expect(component.formControl.value).toBe('foo');
     });
+
+    it('should allow to get control value', () => {
+      fixture.detectChanges();
+      component.formControl.setValue('foo')
+      const customFormControl: MockedComponent<CustomFormControlComponent> = fixture.debugElement.query(
+        By.css('custom-form-control')
+      ).componentInstance;
+      expect(customFormControl.__value).toBe('foo');
+    });
   });
 
   describe('NgTemplateOutlet', () => {


### PR DESCRIPTION
closes https://github.com/ike18t/ng-mocks/issues/126