### PR TITLE
Update project to build to es5 by default

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "lib": ["es2016", "dom"],
     "module": "commonjs",
     "target": "es5",
+    "downlevelIteration": true,
     "noImplicitAny": true,
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es2016", "dom"],
     "module": "commonjs",
-    "target": "es2015",
+    "target": "es5",
     "noImplicitAny": true,
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
Having the default build to es5 keeps full support for all browsers. IE11 for example which ng-mocks does not work on at the moment since version 9.