### PR TITLE
fix: adding NG_VALUE_ACCESSOR only when necessary

### DIFF
--- a/examples/MockReactiveForms/dependency.component.ts
+++ b/examples/MockReactiveForms/dependency.component.ts
@@ -1,6 +1,14 @@
-import { Component } from '@angular/core';
+import { Component, forwardRef } from '@angular/core';
+import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
 @Component({
+  providers: [
+    {
+      multi: true,
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => DependencyComponent),
+    },
+  ],
   selector: 'dependency-component-selector',
   template: `dependency`,
 })

--- a/lib/common/Mock.ts
+++ b/lib/common/Mock.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from '@angular/core';
-import { ControlValueAccessor } from '@angular/forms';
+import { AbstractControl, ControlValueAccessor, ValidationErrors, Validator } from '@angular/forms';
 
 import { mockServiceHelper } from '../mock-service';
 
@@ -54,7 +54,7 @@ export class Mock {
   }
 }
 
-export class MockControlValueAccessor extends Mock implements ControlValueAccessor {
+export class MockControlValueAccessor extends Mock implements ControlValueAccessor, Validator {
   get __ngMocksMockControlValueAccessor(): boolean {
     return true;
   }
@@ -62,6 +62,8 @@ export class MockControlValueAccessor extends Mock implements ControlValueAccess
   __simulateChange = (param: any) => {}; // tslint:disable-line:variable-name
 
   __simulateTouch = () => {}; // tslint:disable-line:variable-name
+
+  __simulateValidatorChange = () => {}; // tslint:disable-line:variable-name
 
   registerOnChange(fn: (value: any) => void): void {
     this.__simulateChange = fn;
@@ -71,5 +73,13 @@ export class MockControlValueAccessor extends Mock implements ControlValueAccess
     this.__simulateTouch = fn;
   }
 
-  writeValue = (value: any) => {};
+  registerOnValidatorChange(fn: () => void): void {
+    this.__simulateValidatorChange = fn;
+  }
+
+  setDisabledState = (isDisabled: boolean): void => {};
+
+  validate = (control: AbstractControl): ValidationErrors | null => null;
+
+  writeValue = (obj: any) => {};
 }

--- a/lib/mock-component/test-components/empty-component.component.ts
+++ b/lib/mock-component/test-components/empty-component.component.ts
@@ -1,6 +1,14 @@
-import { Component } from '@angular/core';
+import { Component, forwardRef } from '@angular/core';
+import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
 @Component({
+  providers: [
+    {
+      multi: true,
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => EmptyComponent),
+    },
+  ],
   selector: 'empty-component',
   template: 'some template',
 })

--- a/tests/issue-145/components.spec.ts
+++ b/tests/issue-145/components.spec.ts
@@ -1,0 +1,82 @@
+import { Component } from '@angular/core';
+import { NG_VALIDATORS, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { MockComponent } from 'ng-mocks';
+import { directiveResolver } from 'ng-mocks/dist/lib/common/reflect';
+
+@Component({
+  selector: 'component',
+  template: '',
+})
+export class ComponentDefault {}
+
+@Component({
+  providers: [
+    {
+      multi: true,
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: ComponentValueAccessor,
+    },
+  ],
+  selector: 'component',
+  template: '',
+})
+export class ComponentValueAccessor {}
+
+@Component({
+  providers: [
+    {
+      multi: true,
+      provide: NG_VALIDATORS,
+      useExisting: ComponentValidator,
+    },
+  ],
+  selector: 'component',
+  template: '',
+})
+export class ComponentValidator {}
+
+// providers should be added to components only in case if they were specified in the original component.
+describe('issue-145', () => {
+  it('ComponentDefault', () => {
+    const mock = MockComponent(ComponentDefault);
+    const { providers } = directiveResolver.resolve(mock);
+    expect(providers).toEqual([
+      {
+        provide: ComponentDefault,
+        useExisting: jasmine.anything(),
+      },
+    ]);
+  });
+
+  it('ComponentValueAccessor', () => {
+    const mock = MockComponent(ComponentValueAccessor);
+    const { providers } = directiveResolver.resolve(mock);
+    expect(providers).toEqual([
+      {
+        provide: ComponentValueAccessor,
+        useExisting: jasmine.anything(),
+      },
+      {
+        multi: true,
+        provide: NG_VALUE_ACCESSOR,
+        useExisting: jasmine.anything(),
+      },
+    ]);
+  });
+
+  it('ComponentValidator', () => {
+    const mock = MockComponent(ComponentValidator);
+    const { providers } = directiveResolver.resolve(mock);
+    expect(providers).toEqual([
+      {
+        provide: ComponentValidator,
+        useExisting: jasmine.anything(),
+      },
+      {
+        multi: true,
+        provide: NG_VALIDATORS,
+        useExisting: jasmine.anything(),
+      },
+    ]);
+  });
+});

--- a/tests/issue-145/directives.spec.ts
+++ b/tests/issue-145/directives.spec.ts
@@ -1,0 +1,79 @@
+import { Directive } from '@angular/core';
+import { NG_VALIDATORS, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { MockDirective } from 'ng-mocks';
+import { directiveResolver } from 'ng-mocks/dist/lib/common/reflect';
+
+@Directive({
+  selector: 'directive',
+})
+export class DirectiveDefault {}
+
+@Directive({
+  providers: [
+    {
+      multi: true,
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: DirectiveValueAccessor,
+    },
+  ],
+  selector: 'directive',
+})
+export class DirectiveValueAccessor {}
+
+@Directive({
+  providers: [
+    {
+      multi: true,
+      provide: NG_VALIDATORS,
+      useExisting: DirectiveValidator,
+    },
+  ],
+  selector: 'directive',
+})
+export class DirectiveValidator {}
+
+// providers should be added to directives only in case if they were specified in the original directive.
+describe('issue-145', () => {
+  it('DirectiveDefault', () => {
+    const mock = MockDirective(DirectiveDefault);
+    const { providers } = directiveResolver.resolve(mock);
+    expect(providers).toEqual([
+      {
+        provide: DirectiveDefault,
+        useExisting: jasmine.anything(),
+      },
+    ]);
+  });
+
+  it('DirectiveValueAccessor', () => {
+    const mock = MockDirective(DirectiveValueAccessor);
+    const { providers } = directiveResolver.resolve(mock);
+    expect(providers).toEqual([
+      {
+        provide: DirectiveValueAccessor,
+        useExisting: jasmine.anything(),
+      },
+      {
+        multi: true,
+        provide: NG_VALUE_ACCESSOR,
+        useExisting: jasmine.anything(),
+      },
+    ]);
+  });
+
+  it('DirectiveValidator', () => {
+    const mock = MockDirective(DirectiveValidator);
+    const { providers } = directiveResolver.resolve(mock);
+    expect(providers).toEqual([
+      {
+        provide: DirectiveValidator,
+        useExisting: jasmine.anything(),
+      },
+      {
+        multi: true,
+        provide: NG_VALIDATORS,
+        useExisting: jasmine.anything(),
+      },
+    ]);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
     "strictNullChecks": true,
     "baseUrl": ".",
     "paths": {
-      "ng-mocks": ["index"]
+      "ng-mocks": ["index"],
+      "ng-mocks/dist/*": ["./*"]
     },
     "skipLibCheck": true
   },


### PR DESCRIPTION
in case of components we add NG_VALUE_ACCESSOR for historical reasons and this behavior wasn't changed.

closes #145