### PR TITLE
fix: should include the keep module

### DIFF
--- a/libs/ng-mocks/src/lib/mock-builder/promise/add-missed-keep-declarations-and-modules.ts
+++ b/libs/ng-mocks/src/lib/mock-builder/promise/add-missed-keep-declarations-and-modules.ts
@@ -8,6 +8,10 @@ import { BuilderData, NgMeta } from './types';
 export default (ngModule: NgMeta, { keepDef, configDef }: BuilderData): void => {
   // Adding missed kept providers to test bed.
   for (const def of mapValues(keepDef)) {
+    if (isNgDef(def, 'm') && !ngModule.imports.includes(def)) {
+      ngModule.imports = ngModule.imports.concat(ngMocksUniverse.cacheDeclarations.get(def));
+    }
+
     if (!isNgDef(def, 'i') && isNgDef(def)) {
       continue;
     }

--- a/tests/issue-377/test.spec.ts
+++ b/tests/issue-377/test.spec.ts
@@ -1,7 +1,12 @@
-import { Component } from '@angular/core';
+import { Component, NgModule } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { MockBuilder, MockRender } from 'ng-mocks';
+
+@NgModule({
+  imports: [ReactiveFormsModule],
+})
+export class TestModule {}
 
 @Component({
   selector: 'app-form',
@@ -23,7 +28,7 @@ describe('issue-377:classic', () => {
   beforeEach(() =>
     TestBed.configureTestingModule({
       declarations: [FormComponent],
-      imports: [ReactiveFormsModule],
+      imports: [ReactiveFormsModule, TestModule],
     }).compileComponents(),
   );
 
@@ -34,7 +39,9 @@ describe('issue-377:classic', () => {
 
 describe('issue-377:mock', () => {
   beforeEach(() =>
-    MockBuilder(FormComponent).keep(ReactiveFormsModule),
+    MockBuilder(FormComponent)
+      .keep(ReactiveFormsModule)
+      .mock(TestModule),
   );
 
   it('sets TestBed correctly', () => {


### PR DESCRIPTION
not sure if it's related with #377, but the issue here is that for the `ReactiveFormsModule`, if using builder to keep `ReactiveFormsModule` and mock another module which also imports the same module, `ReactiveFormsModule` will not be included in the final ngModule. You can refer to the test here. Not sure my solution is totally right, feel free to use the test here for the bug analysis, thanks