### PR TITLE
fix: skipping wrong query selectors #445

### DIFF
--- a/libs/ng-mocks/src/lib/mock-component/render/generate-template.ts
+++ b/libs/ng-mocks/src/lib/mock-component/render/generate-template.ts
@@ -32,9 +32,10 @@ export default (queries?: Record<keyof any, any>): string => {
       continue;
     }
     if (typeof query.selector === 'string') {
-      queries[`__mockView_key_${query.selector}`] = new ViewChild(`key_${query.selector}`, viewChildArgs);
-      queries[`__mockTpl_key_${query.selector}`] = query;
-      parts.push(viewChildTemplate(query.selector, 'key'));
+      const selector = query.selector.replace(new RegExp('[^a-z0-9-_]+', 'mg'), ' ').trim().replace(' ', '_');
+      queries[`__mockView_key_${selector}`] = new ViewChild(`key_${selector}`, viewChildArgs);
+      queries[`__mockTpl_key_${selector}`] = query;
+      parts.push(viewChildTemplate(selector, 'key'));
     }
     queries[`__mockView_prop_${key}`] = new ViewChild(`prop_${key}`, viewChildArgs);
     parts.push(viewChildTemplate(key, 'prop'));

--- a/tests/issue-445/test.spec.ts
+++ b/tests/issue-445/test.spec.ts
@@ -1,0 +1,53 @@
+import { Component, ContentChild } from '@angular/core';
+import { MockBuilder, MockRender } from 'ng-mocks';
+
+@Component({
+  selector: 'target',
+  template: `<ng-content></ng-content>`,
+})
+export class ByAttributeComponent {
+  @ContentChild('[someAttribute]', {} as any)
+  public readonly contentChild?: any;
+}
+
+describe('issue-445', () => {
+  describe('real', () => {
+    beforeEach(() => MockBuilder(ByAttributeComponent));
+
+    it('should render correctly without content child but fails', () => {
+      expect(() =>
+        MockRender('<target></target>', {}, true),
+      ).not.toThrowError();
+    });
+
+    it('should render correctly with content child but fails', () => {
+      expect(() =>
+        MockRender(
+          '<target><ng-template someAttribute>Yeeeeaaah</ng-template></target>',
+          {},
+          true,
+        ),
+      ).not.toThrowError();
+    });
+  });
+
+  describe('mock', () => {
+    beforeEach(() => MockBuilder().mock(ByAttributeComponent));
+
+    it('should render correctly without content child but fails', () => {
+      expect(() =>
+        MockRender('<target></target>', {}, true),
+      ).not.toThrowError();
+    });
+
+    it('should render correctly with content child but fails', () => {
+      expect(() =>
+        MockRender(
+          '<target><ng-template someAttribute>Yeeeeaaah</ng-template></target>',
+          {},
+          true,
+        ),
+      ).not.toThrowError();
+    });
+  });
+});


### PR DESCRIPTION
closes #445