### PR TITLE
docs: covering spectator with standalone components #2921

### DIFF
--- a/docs/articles/extra/with-3rd-party.md
+++ b/docs/articles/extra/with-3rd-party.md
@@ -10,32 +10,44 @@ and at the same time to **turn dependencies into mocks**.
 ## @ngneat/spectator
 
 For example, if there is a need to mock declarations in `@ngneat/spectator` and its functions
-like `createHostFactory`, `createComponentFactory`, `createDirectiveFactory` and so on, we need:
+like `createHostFactory`, `createComponentFactory`, `createDirectiveFactory` and so on,
+you can use two options from `ng-mocks`: [`ngMocks.guts`](../api/ngMocks/guts.md) and [`MockBuilder`](../api/MockBuilder.md)
 
-- exclude the component we want to test
-- to turn declarations of its module into mocks
-- export all declarations the module has
+### @ngneat/spectator and ngMocks.guts
 
-if we use [`ngMocks.guts`](../api/ngMocks/guts.md) we need to skip the first parameter, pass the module
-as the second parameter to export its declaration, and to pass the component as the third one to exclude it.
+if we use [`ngMocks.guts`](../api/ngMocks/guts.md) we need to pass the desired component to the first parameter,
+and its module to pass as the second parameter to extract its guts and mock them.
 
 ```ts
-const dependencies = ngMocks.guts(null, MyModule, MyComponent);
+const dependencies = ngMocks.guts(MyComponent, ItsModule);
 const createComponent = createComponentFactory({
   component: MyComponent,
   ...dependencies,
 });
 ```
 
-If we use [`MockBuilder`](../api/MockBuilder.md) we need [`.exclude`](../api/MockBuilder.md#exclude), [`.mock`](../api/MockBuilder.md#mock) and [`exportAll`](../api/MockBuilder.md#exportall-flag) flag.
+### @ngneat/spectator and MockBuilder
+
+If we use [`MockBuilder`](../api/MockBuilder.md), then we simply build what we need.
+`MyComponent` is kept, whereas all declarations, imports and exports of `ItsModule` are mocked.
 
 ```ts
-const dependencies = MockBuilder(null, MyModule)
-  .exclude(MyComponent)
-  .build();
+const dependencies = MockBuilder(MyComponent, ItsModule).build();
 
 const createComponent = createComponentFactory({
   component: MyComponent,
+  ...dependencies,
+});
+```
+
+Please note, it also covers standalone components, directives and pipes.
+All imports of `StandaloneComponent` will be mocked, whereas the component is available as it is for testing.
+
+```ts
+const dependencies = MockBuilder(StandaloneComponent).build();
+
+const createComponent = createComponentFactory({
+  component: StandaloneComponent,
   ...dependencies,
 });
 ```
@@ -46,18 +58,20 @@ Profit.
 
 The same applies to `@testing-library/angular`.
 
+### @testing-library/angular and ngMocks.guts
+
 In case of [`ngMocks.guts`](../api/ngMocks/guts.md):
 
 ```ts
-const dependencies = ngMocks.guts(null, MyModule, MyComponent);
+const dependencies = ngMocks.guts(MyComponent, ItsModule);
 await render(MyComponent, dependencies);
 ```
+
+### @testing-library/angular and MockBuilder
 
 In case of [`MockBuilder`](../api/MockBuilder.md):
 
 ```ts
-const dependencies = MockBuilder(null, MyModule)
-  .exclude(MyComponent)
-  .build();
+const dependencies = MockBuilder(MyComponent, ItsModule).build();
 await render(MyComponent, dependencies);
 ```

--- a/tests-e2e/package-lock.json
+++ b/tests-e2e/package-lock.json
@@ -33,6 +33,7 @@
         "@angular/cli": "14.0.4",
         "@angular/compiler-cli": "14.0.4",
         "@ngneat/spectator": "11.1.0",
+        "@testing-library/angular": "12.0.2",
         "@types/jasmine": "4.0.3",
         "@types/jest": "28.1.4",
         "@types/mocha": "9.1.1",
@@ -2941,6 +2942,23 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.23.5.tgz",
       "integrity": "sha512-AFBVi/iT4g20DHoujvMH1aEDn8fGJh4xsRGCP6d8RpLPMqsNPvW01Jcn0QysXTsg++/xj25NmJsGyH9xug/wKg==",
       "dev": true
+    },
+    "node_modules/@testing-library/angular": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/angular/-/angular-12.0.2.tgz",
+      "integrity": "sha512-iNm2UvX2tOtz1EOI7UiFRowRUIh1HDkahhAERF9wB6mcIix2RF/ivw1BqOAzRtYY+nsTbTc/gXhz1KAczbyjHQ==",
+      "dev": true,
+      "dependencies": {
+        "@testing-library/dom": "^8.0.0",
+        "tslib": "^2.3.1"
+      },
+      "peerDependencies": {
+        "@angular/common": ">= 14.0.0",
+        "@angular/core": ">= 14.0.0",
+        "@angular/platform-browser": ">= 14.0.0",
+        "@angular/router": ">= 14.0.0",
+        "rxjs": ">= 7.4.0"
+      }
     },
     "node_modules/@testing-library/dom": {
       "version": "8.14.0",
@@ -17624,6 +17642,16 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.23.5.tgz",
       "integrity": "sha512-AFBVi/iT4g20DHoujvMH1aEDn8fGJh4xsRGCP6d8RpLPMqsNPvW01Jcn0QysXTsg++/xj25NmJsGyH9xug/wKg==",
       "dev": true
+    },
+    "@testing-library/angular": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/angular/-/angular-12.0.2.tgz",
+      "integrity": "sha512-iNm2UvX2tOtz1EOI7UiFRowRUIh1HDkahhAERF9wB6mcIix2RF/ivw1BqOAzRtYY+nsTbTc/gXhz1KAczbyjHQ==",
+      "dev": true,
+      "requires": {
+        "@testing-library/dom": "^8.0.0",
+        "tslib": "^2.3.1"
+      }
     },
     "@testing-library/dom": {
       "version": "8.14.0",

--- a/tests-e2e/package.json
+++ b/tests-e2e/package.json
@@ -43,6 +43,7 @@
     "@angular/cli": "14.0.4",
     "@angular/compiler-cli": "14.0.4",
     "@ngneat/spectator": "11.1.0",
+    "@testing-library/angular": "12.0.2",
     "@types/jasmine": "4.0.3",
     "@types/jest": "28.1.4",
     "@types/mocha": "9.1.1",

--- a/tests-e2e/src/issue-971/test.spec.ts
+++ b/tests-e2e/src/issue-971/test.spec.ts
@@ -51,9 +51,10 @@ describe('issue-971', () => {
   describe('MockBuilder', () => {
     let spectator: Spectator<TargetComponent>;
 
-    const dependencies = MockBuilder(null, TargetModule)
-      .exclude(TargetComponent)
-      .build();
+    const dependencies = MockBuilder(
+      TargetComponent,
+      TargetModule,
+    ).build();
     const createComponent = createComponentFactory({
       component: TargetComponent,
       ...dependencies,

--- a/tests-e2e/src/spectator/classic.spec.ts
+++ b/tests-e2e/src/spectator/classic.spec.ts
@@ -1,0 +1,78 @@
+import { Component, NgModule } from '@angular/core';
+import { createComponentFactory, Spectator } from '@ngneat/spectator';
+import { MockBuilder, ngMocks } from 'ng-mocks';
+
+@Component({
+  selector: 'header',
+  template: 'header',
+})
+class HeaderComponent {}
+
+@Component({
+  selector: 'target',
+  template: '<header></header>',
+})
+class TargetComponent {}
+
+@NgModule({
+  declarations: [TargetComponent, HeaderComponent],
+})
+class TargetModule {}
+
+describe('spectator:classic', () => {
+  describe('TestBed', () => {
+    let spectator: Spectator<TargetComponent>;
+
+    const createComponent = createComponentFactory({
+      component: TargetComponent,
+      declarations: [HeaderComponent],
+    });
+
+    beforeEach(() => (spectator = createComponent()));
+
+    it('keeps header', () => {
+      expect(ngMocks.formatHtml(spectator.fixture)).toEqual(
+        '<header>header</header>',
+      );
+    });
+  });
+
+  describe('ngMocks.guts', () => {
+    let spectator: Spectator<TargetComponent>;
+
+    const dependencies = ngMocks.guts(TargetComponent, TargetModule);
+    const createComponent = createComponentFactory({
+      component: TargetComponent,
+      ...dependencies,
+    });
+
+    beforeEach(() => (spectator = createComponent()));
+
+    it('mocks header', () => {
+      expect(ngMocks.formatHtml(spectator.fixture)).toEqual(
+        '<header></header>',
+      );
+    });
+  });
+
+  describe('MockBuilder', () => {
+    let spectator: Spectator<TargetComponent>;
+
+    const dependencies = MockBuilder(
+      TargetComponent,
+      TargetModule,
+    ).build();
+    const createComponent = createComponentFactory({
+      component: TargetComponent,
+      ...dependencies,
+    });
+
+    beforeEach(() => (spectator = createComponent()));
+
+    it('mocks header', () => {
+      expect(ngMocks.formatHtml(spectator.fixture)).toEqual(
+        '<header></header>',
+      );
+    });
+  });
+});

--- a/tests-e2e/src/spectator/standalone.spec.ts
+++ b/tests-e2e/src/spectator/standalone.spec.ts
@@ -1,0 +1,55 @@
+import { Component } from '@angular/core';
+import { createComponentFactory, Spectator } from '@ngneat/spectator';
+import { MockBuilder, ngMocks } from 'ng-mocks';
+
+@Component({
+  selector: 'header',
+  template: 'header',
+  standalone: true,
+} as never)
+class HeaderComponent {}
+
+@Component({
+  selector: 'target',
+  template: '<header></header>',
+  standalone: true,
+  imports: [HeaderComponent],
+} as never)
+class TargetComponent {}
+
+// @see https://stackoverflow.com/questions/72708580/mockcomponent-still-includes-the-actual-component
+describe('spectator:standalone', () => {
+  describe('TestBed', () => {
+    let spectator: Spectator<TargetComponent>;
+
+    const createComponent = createComponentFactory({
+      component: TargetComponent,
+    });
+
+    beforeEach(() => (spectator = createComponent()));
+
+    it('keeps header', () => {
+      expect(ngMocks.formatHtml(spectator.fixture)).toEqual(
+        '<header>header</header>',
+      );
+    });
+  });
+
+  describe('MockBuilder', () => {
+    let spectator: Spectator<TargetComponent>;
+
+    const dependencies = MockBuilder(TargetComponent).build();
+    const createComponent = createComponentFactory({
+      component: TargetComponent,
+      ...dependencies,
+    });
+
+    beforeEach(() => (spectator = createComponent()));
+
+    it('mocks header', () => {
+      expect(ngMocks.formatHtml(spectator.fixture)).toEqual(
+        '<header></header>',
+      );
+    });
+  });
+});

--- a/tests-e2e/src/testing-library/classic.spec.ts
+++ b/tests-e2e/src/testing-library/classic.spec.ts
@@ -1,0 +1,58 @@
+import { Component, NgModule } from '@angular/core';
+import { render } from '@testing-library/angular';
+import { MockBuilder, ngMocks } from 'ng-mocks';
+
+@Component({
+  selector: 'header',
+  template: 'header',
+})
+class HeaderComponent {}
+
+@Component({
+  selector: 'target',
+  template: '<header></header>',
+})
+class TargetComponent {}
+
+@NgModule({
+  declarations: [TargetComponent, HeaderComponent],
+})
+class TargetModule {}
+
+describe('testing-library:classic', () => {
+  describe('TestBed', () => {
+    it('keeps header', async () => {
+      const context = await render(TargetComponent, {
+        declarations: [HeaderComponent],
+      });
+      expect(ngMocks.formatHtml(context.fixture)).toEqual(
+        '<header>header</header>',
+      );
+    });
+  });
+
+  describe('ngMocks.guts', () => {
+    const dependencies = ngMocks.guts(TargetComponent, TargetModule);
+
+    it('mocks header', async () => {
+      const context = await render(TargetComponent, dependencies);
+      expect(ngMocks.formatHtml(context.fixture)).toEqual(
+        '<header></header>',
+      );
+    });
+  });
+
+  describe('MockBuilder', () => {
+    const dependencies = MockBuilder(
+      TargetComponent,
+      TargetModule,
+    ).build();
+
+    it('mocks header', async () => {
+      const context = await render(TargetComponent, dependencies);
+      expect(ngMocks.formatHtml(context.fixture)).toEqual(
+        '<header></header>',
+      );
+    });
+  });
+});

--- a/tests-e2e/src/testing-library/standalone.spec.ts
+++ b/tests-e2e/src/testing-library/standalone.spec.ts
@@ -1,0 +1,40 @@
+import { Component } from '@angular/core';
+import { render } from '@testing-library/angular';
+import { MockBuilder, ngMocks } from 'ng-mocks';
+
+@Component({
+  selector: 'header',
+  template: 'header',
+  standalone: true,
+} as never)
+class HeaderComponent {}
+
+@Component({
+  selector: 'target',
+  template: '<header></header>',
+  standalone: true,
+  imports: [HeaderComponent],
+} as never)
+class TargetComponent {}
+
+describe('testing-library:standalone', () => {
+  describe('TestBed', () => {
+    it('keeps header', async () => {
+      const context = await render(TargetComponent);
+      expect(ngMocks.formatHtml(context.fixture)).toEqual(
+        '<header>header</header>',
+      );
+    });
+  });
+
+  describe('MockBuilder', () => {
+    const dependencies = MockBuilder(TargetComponent).build();
+
+    it('mocks header', async () => {
+      const context = await render(TargetComponent, dependencies);
+      expect(ngMocks.formatHtml(context.fixture)).toEqual(
+        '<header></header>',
+      );
+    });
+  });
+});


### PR DESCRIPTION
closes #2921 